### PR TITLE
ICRC-25 ref impl: Refactor signer polling

### DIFF
--- a/reference-implementations/icrc25/signer/src/App.js
+++ b/reference-implementations/icrc25/signer/src/App.js
@@ -6,7 +6,7 @@ import { principalToSubAccount } from '@dfinity/utils'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import './App.css';
-import { call, createAgent, readState } from './agent';
+import { call, createAgent, pollForCert } from './agent';
 import { createWalletClient } from './beacon'
 import { BalanceArgs, BalanceResult, ConsentMessageRequest, ConsentMessageResponse, ICRC1TransferArgs, ICRC1TransferResult, MintArgs, MintResult, idlDecode, idlEncode } from './idl';
 
@@ -280,12 +280,12 @@ function App() {
       })
     } else {
       try {
-        const readStateResponse = await readState(agent, pendingCanisterCallRequest.params.canisterId, callResponse.requestId)
+        const cert = await pollForCert(agent, pendingCanisterCallRequest.params.canisterId, callResponse.requestId)
         await client.ic.respondWithResult(pendingCanisterCallRequest, {
           version: '1',
           network: pendingCanisterCallRequest.network,
           contentMap,
-          certificate: Buffer.from(readStateResponse.certificate).toString('base64')
+          certificate: Buffer.from(cert).toString('base64')
         })
       } catch (e) {
         console.error(e)


### PR DESCRIPTION
This PR simplifies polling by making use of the
standard changes that all certified terminal states should (from the point of view of the signer) not be treated as an error, but simply returned to the relying party.