### PR TITLE
ICRC-21: Specify message context

### DIFF
--- a/topics/icrc_21_consent_msg.md
+++ b/topics/icrc_21_consent_msg.md
@@ -61,6 +61,18 @@ type icrc21_consent_info = record {
     // It should only contain information that is:
     // * relevant to the user
     // * relevant given the canister call argument
+    //
+    // The message must fit the following context shown to
+    // the user on the signer UI:
+    // ┌─────────────────────────────────┐
+    // │  Approve the following action?  │
+    // │  ┌───────────────────────────┐  │
+    // │  │    <consent_message>      │  │
+    // │  └───────────────────────────┘  │
+    // │  ┌───────────┐   ┌───────────┐  │
+    // │  │  Reject   │   │  Approve  │  │
+    // │  └───────────┘   └───────────┘  │
+    // └─────────────────────────────────┘
     consent_message: text;
     // Same semantics as HTTP lang attribute
     language: text;
@@ -290,4 +302,22 @@ Argument for the ledger canister call to `icrc21_consent_message`:
       }
    }
 )
+```
+### Signer UI Approval Screen
+
+The message will then be shown to the user in the following context:
+
+```
+┌─────────────────────────────────┐
+│  Approve the following action?  │
+│  ┌───────────────────────────┐  │
+│  │ Transfer 7.89 ICP to      │  │
+│  │ account ed2182...,        │  │
+│  │ include memo: 123.        │  │
+│  │ Fee: 0.0001 ICP.          │  │
+│  └───────────────────────────┘  │
+│  ┌───────────┐   ┌───────────┐  │
+│  │  Reject   │   │  Approve  │  │
+│  └───────────┘   └───────────┘  │
+└─────────────────────────────────┘
 ```


### PR DESCRIPTION
This PR specifies the consent message context more clearly to help developers chose an appropriate message when developing their canister.
This context is also added to the example.