### PR TITLE
ICRC-29: Make method prefix consistent with ICRC-25

### DIFF
--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -21,12 +21,12 @@ For this standard to represent an [ICRC-25](https://github.com/dfinity/wg-identi
 ## Establishing a Communication Channel
 
 A window post message communication channel is initiated by the relying party. The relying party opens a new window and waits for the signer to send a message indicating that it is ready for interactions.
-The message is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) notification with the method `icrc-29_ready` and no parameters:
+The message is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) notification with the method `icrc29_ready` and no parameters:
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "icrc-29_ready"
+    "method": "icrc29_ready"
 }
 ```
 


### PR DESCRIPTION
This PR makes the JSON-RPC 2.0 method prefix consistent with ICRC-25 messages.