### PR TITLE
ICRC-25: Split out identity information from `icrc25_request_permission` method

### DIFF
--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -100,15 +100,16 @@ While processing the request from the relying party, the signer can cancel it at
     - If the request version is not supported by the signer, the signer sends a response with an error back to the relying party.
 3. The signer removes any unrecognized scopes from the list of requested scopes.
 4. Depending on the session state the signer either skips or displays the details of the to-be-established connection to the user:
-    - If there is no ongoing session with the relying party:
+    - If there is an active session with the relying party, skip to the next step, otherwise:
         - the signer presents the details of the to-be-established connection to the user. If the user has never interacted with this relying party before, the signer should display information explaining that the user is about to establish a connection with a new relying party.
+        - If the user approves the connection, the signer creates a new session for the relying party.
+            - Otherwise, the signer sends a response with an error back to the relying party and step 5 is skipped.
 
       > **Note:** The signer should maintain a list of relying parties that are trusted by the user. It is recommended that signers assist users when deciding to grant permissions to new relying parties, e.g. by maintaining a list of well-known relying parties and displaying additional information about the relying party, such as its name, logo, etc., or in the case of an unknown relying party, by displaying a warning.
-
-    - If there already is an active session with the relying party, the signer skips this step.
+      
 5. The signer displays the list of requested scopes to the user and asks the user to approve or reject the request. The user should also be allowed to approve only a subset of the requested scopes or add additional restrictions (see [optional scope restrictions](#optional-properties)).
     - If all requested scopes have already been granted, the signer may skip the user interaction and reply with the list of granted scopes immediately.
-    - If the user approves the request, the signer saves information about the granted permission scopes on the current session. If there is no active session, a new one must be created. Then the signer sends a successful response back to the relying party with the list of granted scopes.
+    - If the user approves the request, the signer saves information about the granted permission scopes on the current session. Then the signer sends a successful response back to the relying party with the list of granted scopes.
     - If the user rejects the request, the signer sends a response with an error back to the relying party.
 6. After receiving a response, the relying party may send additional messages depending on the granted scopes.
 

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -95,7 +95,7 @@ While processing the request from the relying party, the signer can cancel it at
 3. The signer removes any unrecognized scopes from the list of requested scopes.
 4. Depending on the session state the signer either skips or displays the details of the to-be-established connection to the user:
     - If there is no ongoing session with the relying party:
-        - the signer presents the details of the to-be-established connection to the user and asks the user to select identities that will be paired in response. If the user has never interacted with this relying party before, the signer should display information explaining that the user is about to establish a connection with a new relying party.
+        - the signer presents the details of the to-be-established connection to the user. If the user has never interacted with this relying party before, the signer should display information explaining that the user is about to establish a connection with a new relying party.
 
       > **Note:** The signer should maintain a list of relying parties that are trusted by the user. It is recommended that signers assist users when deciding to grant permissions to new relying parties, e.g. by maintaining a list of well-known relying parties and displaying additional information about the relying party, such as its name, logo, etc., or in the case of an unknown relying party, by displaying a warning.
 

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -47,9 +47,10 @@ Scopes are represented in JSON-RPC 2.0 messages as JSON objects with the followi
 ### List of Scopes
 
 This standard defines the following `method` values for scopes:
+* `icrc25_get_identities`
 * `icrc25_canister_call`
 
-This list can be extended by other standards.
+This list may be extended by other standards.
 
 ## Batch Calls
 
@@ -61,7 +62,7 @@ If a signer receives a batch call, it must process each request sequentially in 
 
 ### `icrc25_request_permission`
 
-The purpose of the `icrc25_request_permission` messages is to grant the relying party access to public parts of the user's identity and define the scope of actions the relying part is allowed to perform.
+The purpose of the `icrc25_request_permission` message is for the relying party to request [permission scopes](#scopes) to perform further actions. If the set of granted scopes is not empty and there was no session before, a new [session](#sessions) is created.
 
 #### Prerequisites
 
@@ -73,17 +74,11 @@ None
 
 `scopes`: A list of permission [scope objects](#scope-objects) the relying party requires. If the signer does not support a requested scope, it should ignore that particular scope and proceed as if the `scopes` list did not include that object.
 
-`challenge` (`blob`): A challenge used for the signer to sign in order to prove its access to the identity. The challenge should be an array of 32 cryptographically random bytes generated from a secure random source by the sender of the request.
-
 #### Response
 
 `version` (`text`): The version of the standard used. It must match the `version` from the request.
 
-`scopes`: A list of permission [scope objects](#scope-objects) that the signer supports and the user has agreed the relying party can be granted. This must be a subset of the `scopes` field from the original request.
-
-`identities`: A list of identities the user has selected to share with the relying party.
-- `publicKey` (`blob`): The DER-encoded public key associated with the identity, derived in accordance with one of [the signature algorithms supported by the IC](https://internetcomputer.org/docs/current/references/ic-interface-spec/#signatures). The public key can be used to [derive a self-authenticating principal](https://internetcomputer.org/docs/current/references/ic-interface-spec/#principal).
-- `signature` (`blob`): The signature produced by signing the concatenation of the domain separator `\x13ic-signer-challenge` (UTF-8 encoded) and the challenge with the private key associated with the identity.
+`scopes`: A list of permission [scope objects](#scope-objects) that the signer supports and the user has granted the relying party. This list includes all granted scopes on the current session.
 
 #### Errors
 
@@ -94,20 +89,22 @@ While processing the request from the relying party, the signer can cancel it at
 
 #### Use-Case
 
-1. The relying party sends a `icrc25_request_permission` request to the signer.
+1. The relying party sends a `icrc25_request_permission` message to the signer.
 2. Upon receiving the message, the signer first checks if it can process the message.
     - If the request version is not supported by the signer, the signer sends a response with an error back to the relying party.
-3. Next, the signer presents the details of the to-be-established connection to the user and asks the user to select identities that will be paired in response. If the user has never interacted with this relying party before, the signer should display information explaining that the user is about to establish a connection with a new relying party.
-    > **Note:** The signer should maintain a list of relying parties that are trusted by the user. It is recommended that signers
-    assist users when deciding to grant permissions to new relying parties, e.g. by maintaining a list of well-known relying parties
-    and displaying additional information about the relying party, such as its name, logo, etc., or in the case of an unknown relying
-    party, by displaying a warning. 
-    - If the user approves the request, the signer saves information about the granted permission scopes and sends a successful response back to the relying party.
+3. The signer removes any unrecognized scopes from the list of requested scopes.
+4. Depending on the session state the signer either skips or displays the details of the to-be-established connection to the user:
+    - If there is no ongoing session with the relying party:
+        - the signer presents the details of the to-be-established connection to the user and asks the user to select identities that will be paired in response. If the user has never interacted with this relying party before, the signer should display information explaining that the user is about to establish a connection with a new relying party.
+
+      > **Note:** The signer should maintain a list of relying parties that are trusted by the user. It is recommended that signers assist users when deciding to grant permissions to new relying parties, e.g. by maintaining a list of well-known relying parties and displaying additional information about the relying party, such as its name, logo, etc., or in the case of an unknown relying party, by displaying a warning.
+
+    - If there already is an active session with the relying party, the signer skips this step.
+5. The signer displays the list of requested scopes to the user and asks the user to approve or reject the request. The user should also be allowed to approve only a subset of the requested scopes.
+    - If all requested scopes have already been granted, the signer may skip the user interaction and reply with the list of granted scopes immediately.
+    - If the user approves the request, the signer saves information about the granted permission scopes on the current session. If there is no active session, a new one must be created. Then the signer sends a successful response back to the relying party with the list of all granted scopes on the current session.
     - If the user rejects the request, the signer sends a response with an error back to the relying party.
-4. After receiving a successful response, the relying party verifies that the signer has access to the private key associated with the provided identities:
-    - The relying party retrieves the `publicKey` from each `identities` value, determines the `signature` scheme and verifies whether it was generated by signing the concatenation of the domain separator `\x13ic-signer-challenge` (UTF-8 encoded) and the `challenge` from the request with the private key associated with the `publicKey`.
-        - If the signature verification succeeds for all `identities`, the relying party accepts the connection.
-        - If the signature verification fails for any `identities` value, the relying party rejects the connection.
+6. After receiving a response, the relying party may send additional messages depending on the granted scopes.
 
 ```mermaid
 sequenceDiagram
@@ -119,13 +116,17 @@ sequenceDiagram
     alt Version is not supported
         S ->> RP: Error response: Version not supported (20101)
     else
-        S ->> U: Display connection details and requested scopes<br/> Ask to select identities to share with Relying Party
+        opt If there is no active session<br>with the relying party
+            S ->> U: Show connection details
+        end
         alt Approved
-            U ->> S: Select identities<br/>Approve request
+            Note over S,U: If either approval is not given,<br>jump to "Rejected" branch
+            U ->> S: Approve connection or existing session
+            S ->> U: Display requested scopes
+
+            U ->> S: Approve request
             S ->> S: Store the granted permission scopes
-            S ->> S: Sign the challenge
             S ->> RP: Permission response
-            RP ->> RP: Verify the signatures
         else Rejected
             U ->> S: Reject request
             S ->> RP: Error response: Permission not granted (30101)
@@ -143,9 +144,109 @@ Request
     "method": "icrc25_request_permission",
     "params": {
         "version": "1",
-        "scopes": [{
-          "method": "icrc25_canister_call"
-        }],
+        "scopes": [
+            {
+                "method": "icrc25_get_identities"
+            },
+            {
+                "method": "icrc25_canister_call"
+            }
+        ]
+    }
+}
+```
+
+Response
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "version": "1",
+        "scopes": [
+            {
+                "method": "icrc25_get_identities"
+            }
+        ]
+    }
+}
+```
+
+### `icrc25_get_identities`
+
+The purpose of the `icrc25_get_identities` message is for the relying party to receive information about the identities managed by the signer.
+
+#### Prerequisites
+
+* Active session with granted scope `icrc25_get_identities`.
+
+#### Request
+
+`version` (`text`): The version of the standard used. If the signer does not support the version of the request, it must send the `"VERSION_NOT_SUPPORTED"` error in response.
+
+`challenge` (`blob`): A challenge used for the signer to sign in order to prove its access to the identity. The challenge should be an array of 32 cryptographically random bytes generated from a secure random source by the sender of the request.
+
+#### Response
+
+`version` (`text`): The version of the standard used. It must match the `version` from the request.
+
+`identities`: A list of identities the user has selected to share with the relying party.
+- `publicKey` (`blob`): The DER-encoded public key associated with the identity, derived in accordance with one of [the signature algorithms supported by the IC](https://internetcomputer.org/docs/current/references/ic-interface-spec/#signatures). The public key can be used to [derive a self-authenticating principal](https://internetcomputer.org/docs/current/references/ic-interface-spec/#principal).
+- `signature` (`blob`): The signature produced by signing the concatenation of the domain separator `\x13ic-signer-challenge` (UTF-8 encoded) and the challenge with the private key associated with the identity.
+
+#### Errors
+
+While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors, the following values are applicable:
+- `10001 Unknown error`
+- `20101 Version not supported`
+- `30101 Permission not granted`
+
+#### Use-Case
+
+1. The relying party sends a `icrc25_get_identities` request to the signer.
+2. Upon receiving the message, the signer first checks if it can process the message.
+    - If the request version is not supported by the signer, the signer sends a response with an error back to the relying party.
+    - If the relying party has not been granted the permission to request the action, the signer sends a response with an error back to the relying party.
+3. Next, the signer lets the user select identities that will be included in the response.
+    - If the user has previously selected identities for the same relying party on the same session, the signer may skip the user interaction.
+4. The signer signs the challenge with the private keys associated with the selected identities and sends a successful response back to the relying party with the list of selected identities and the matching signatures.
+5. After receiving a successful response, the relying party verifies that the signer has access to the private key associated with the provided identities:
+    - The relying party retrieves the `publicKey` from each `identities` value, determines the `signature` scheme and verifies whether it was generated by signing the concatenation of the domain separator `\x13ic-signer-challenge` (UTF-8 encoded) and the `challenge` from the request with the private key associated with the `publicKey`.
+        - If the signature verification succeeds for all `identities`, the relying party accepts the response.
+        - If the signature verification fails for any `identities` value, the relying party rejects the response.
+
+```mermaid
+sequenceDiagram
+    participant RP as Relying Party
+    participant S as Signer
+    participant U as User
+
+    RP ->> S: Request identities
+    alt Version is not supported
+        S ->> RP: Error response: Version not supported (20101)
+    else Scope `icrc25_get_identities` not granted
+        S ->> RP: Error response: Permission not granted (30101)
+    else
+        opt If not selected before on the active session 
+            S ->> U: Ask to select identities to share with Relying Party
+            U ->> S: Select identities
+        end
+        S ->> S: Sign the challenge
+        S ->> RP: Identities response
+        RP ->> RP: Verify the signatures
+    end
+```
+
+#### Example
+
+Request
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "icrc25_get_identities",
+    "params": {
+        "version": "1",
         "challenge": "UjwgsORvEzp98TmB1cAIseNOoD9+GLyN/1DzJ5+jxZM="
     }
 }
@@ -158,9 +259,6 @@ Response
     "jsonrpc": "2.0",
     "result": {
         "version": "1",
-        "scopes": [{
-          "method": "icrc25_canister_call"
-        }],
         "identities": [
             {
                 "publicKey": "MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEOTdHYwpFTr/oPXOfLQcteymk8AQE41VwPQ1W7Xpm0Zt1AY4+5aOnMAbAIjXEchxPuGbPWqPqwntXMPs3w4rOaA==",
@@ -213,13 +311,16 @@ While processing the request from the relying party, the signer can cancel it at
 2. Upon receiving the request, the signer validates whether it can process the message.
     - If the request version is not supported by the signer, the signer sends a response with an error back to the relying party.
     - If the relying party has not been granted the permission to request the action, the signer sends a response with an error back to the relying party.
-3. Next, the signer processes the message following the [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/consent-msg.md) specification. If the target canister does not support ICRC-21, the signer should display a warning, try to decode the arguments by itself and display raw canister call details. If the arguments cannot be decoded, a proper warning must be displayed.
+3. Next, the signer processes the message following the [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/consent-msg.md) specification. If the target canister does not support ICRC-21, the signer should display a warning, try to decode the arguments by itself and display raw canister call details. If the arguments cannot be decoded, a strong warning must be displayed.
     - If the user approves the request:
         - The signer sends the call to the IC (in order to get a certified results, all calls, including queries, should be sent as `update` calls), retrieves its [content map](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-call) and [calculates a request id](https://internetcomputer.org/docs/current/references/ic-interface-spec/#request-id) based on it.
             - The signer continues to call `read_state` for the calculated request id until [the status of the call](https://internetcomputer.org/docs/current/references/ic-interface-spec/#state-tree-request-status) indicates that the call has been processed (succesfully or not).
                 - If the status of the call is `replied`, `rejected` or `done`, the signer retrieves the CBOR-encoded [certificate](https://internetcomputer.org/docs/current/references/ic-interface-spec/#certificate) from [the `read_state` response](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-read-state) and sends it together with the content map in response back to the relying party.
             - If the status of the HTTP response for submitting the call to the IC is _not_ `202 Accepted` (indicating the call failed), the signer sends a response with an error back to the relying party.
     - If the user rejects the request or if the signer fails to complete the requested action for any reason, the signer sends a response with an error back to the relying party.
+
+    > **Note:** Unlike other methods defined in this standard, user approval for the `icrc25_canister_call` method must never be skipped! The reason for this is that the canister call might not be idempotent and thus submitting a call twice might have undesired consequences.
+
 4. The relying party receives a response from the signer and processes it as follows:
     - On successful response: the relying party verifies whether the call performed by the signer was genuine and retrieves the result:
         - The relying party retrieves the CBOR-encoded `contentMap` from the response, verifies that its values match the expectations and uses it to [calculate a request id](https://internetcomputer.org/docs/current/references/ic-interface-spec/#request-id).


### PR DESCRIPTION
This PR splits the identitiy information part of the existing `icrc25_request_permission` method into another method called `icrc25_get_identities`. This makes the methods more focused.

The PR also adds clarifying information about how user interaction should be handled for the given methods. In particular, it allows signers to skip user interaction if the user previously approved the same request.