### PR TITLE
ICRC-21: Make method name more descriptive

### DIFF
--- a/topics/icrc_21_consent_msg.md
+++ b/topics/icrc_21_consent_msg.md
@@ -113,7 +113,7 @@ service : {
     // If the call is made with a non-anonymous identity, the response may be tailored to the identity.
     //
     // This is currently an update call. As soon as secure (replicated) query calls are available, this will be changed to such a replicated query call.
-    icrc21_consent_message: (icrc21_consent_message_request) -> (opt icrc21_consent_message_response);
+    icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (opt icrc21_consent_message_response);
 
     // Returns a list of supported standards related to consent messages that this canister implements.
     // The result should always have at least one entry: record { name = "ICRC-21"; url = "https://github.com/dfinity/wg-identity-authentication" }


### PR DESCRIPTION
In order to make the use-case of ICEC-21 clearer, the method icrc21_consent_message is renamed to
icrc21_canister_call_consent_message.

This rename is in anticipation of extensions to ICRC-21 that will introduce their own flavour of `consent_message` methods.