### PR TITLE
ICRC-25: List predefined errors explicitly

### DIFF
--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -141,7 +141,7 @@ None
 
 #### Errors
 
-While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors, the following values are applicable:
+While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors ([-32600 to -32603 and -32700](https://www.jsonrpc.org/specification#error_object)), the following values are applicable:
 - `10001 Unknown error`
 - `20101 Version not supported`
 - `30101 Permission not granted`
@@ -258,7 +258,7 @@ None
 
 #### Errors
 
-While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors, the following values are applicable:
+While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors ([-32600 to -32603 and -32700](https://www.jsonrpc.org/specification#error_object)), the following values are applicable:
 - `10001 Unknown error`
 - `20101 Version not supported`
 
@@ -347,7 +347,7 @@ The purpose of the `icrc25_managed_identities` message is for the relying party 
 
 #### Errors
 
-While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors, the following values are applicable:
+While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors ([-32600 to -32603 and -32700](https://www.jsonrpc.org/specification#error_object)), the following values are applicable:
 - `10001 Unknown error`
 - `20101 Version not supported`
 - `30101 Permission not granted`
@@ -458,7 +458,7 @@ This message can be used by the relying party to request canister calls to be ex
 
 #### Errors
 
-While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors, the following values are applicable:
+While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors ([-32600 to -32603 and -32700](https://www.jsonrpc.org/specification#error_object)), the following values are applicable:
 - `10001 Unknown error`
 - `20101 Version not supported`
 - `30101 Permission not granted`
@@ -589,7 +589,7 @@ None
 
 #### Errors
 
-While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors, the following values are applicable:
+While processing the request from the relying party, the signer can cancel it at any time by sending an [error](#errors) in response. In addition to the pre-defined JSON-RPC 2.0 errors ([-32600 to -32603 and -32700](https://www.jsonrpc.org/specification#error_object)), the following values are applicable:
 - `10001 Unknown Error`
 - `20101 Version not supported`
 


### PR DESCRIPTION
As requested in the working group, the list of predefined errors is mentioned explictly to make it less likely that devs miss those errors codes.