### PR TITLE
Update signer overview reference to ICRC-27

### DIFF
--- a/topics/signer_standards_overview.md
+++ b/topics/signer_standards_overview.md
@@ -7,7 +7,7 @@ The following ICRC standards are relevant in this context:
 * The [Internet Computer Interface Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec/), specifically the [HTTPs interface](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-interface)
 * [ICRC-21](icrc_21_consent_msg.md): Canister Call Consent Messages
 * [ICRC-25](icrc_25_signer_interaction_standard.md): Signer Interaction Standard
-* ICRC-27: ICRC-25 Extension for ICRC-1 ledger subaccounts
+* [ICRC-27](icrc_27_get_icrc_1_subaccounts.md): Get ICRC-1 ledger accounts (ICRC-25 Extension)
 * [ICRC-29](icrc_29_window_post_message_transport.md): PostMessage Transport Standard for ICRC-25
 * [ICRC-31](icrc_31_get_principals.md): Get Principals (ICRC-25 Extension)
 * [ICRC-32](icrc_32_sign_challenge.md): Sign Challenge (ICRC-25 Extension)


### PR DESCRIPTION
Adds a link to the draft of ICRC-27 to the signer overview.