### PR TITLE
ICRC-25: Point standard links to ICRC repos

### DIFF
--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -473,11 +473,11 @@ Response
     "supportedStandards": [
       {
         "name": "ICRC-25",
-        "url": "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md"
+        "url": "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-25/ICRC-25.md"
       },
       {
         "name": "ICRC-31",
-        "url": "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_31_get_principals.md"
+        "url": "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-31/ICRC-31.md"
       }
     ]
   }


### PR DESCRIPTION
When finalized, the standards need to be available in the ICRC repo. To not upend how this working group operates, we will continue in this repository while the standards are in draft. However, we prepare the drafts such that the transition is easy once finalize. To that end, we already point to the location where the standard will end up eventually when querying supported standards.