### PR TITLE
ICRC-27: Drop version and align errors

### DIFF
--- a/topics/icrc_27_get_icrc_1_accounts.md
+++ b/topics/icrc_27_get_icrc_1_accounts.md
@@ -11,9 +11,9 @@
   * [Scope (according to the ICRC-25 standard)](#scope-according-to-the-icrc-25-standard)
     * [Example Permission Request](#example-permission-request)
   * [`icrc25_supported_standards`](#icrc25_supported_standards)
-  * [Request](#request)
+  * [Request Params](#request-params)
     * [Example RPC Request](#example-rpc-request)
-  * [Response](#response)
+  * [Result](#result)
     * [Example RPC Response](#example-rpc-response)
   * [Message Processing](#message-processing)
   * [Errors](#errors)
@@ -65,7 +65,6 @@ Example usages:
   "jsonrpc": "2.0",
   "method": "icrc25_request_permissions",
   "params": {
-    "version": "1",
     "scopes": [
       {
         "method": "icrc27_get_icrc1_accounts"
@@ -82,10 +81,9 @@ the [icrc25_supported_standards](./icrc_25_signer_interaction_standard.md#icrc25
 returns the list of supported standards. Any signer implementing ICRC-27 must include a record with the name field equal
 to "ICRC-27" in that list.
 
-## Request
+## Request Params
 
-**`version` (`text`):** The version of the standard used. If the signer does not support the version of the request, it
-must send the `"VERSION_NOT_SUPPORTED"` error in response.
+None
 
 ### Example RPC Request
 
@@ -93,16 +91,11 @@ must send the `"VERSION_NOT_SUPPORTED"` error in response.
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "method": "icrc27_get_icrc1_accounts",
-  "params": {
-    "version": "1"
-  }
+  "method": "icrc27_get_icrc1_accounts"
 }
 ```
 
-## Response
-
-**`version` (`text`):** The version of the standard used. It must match the `version` from the request.
+## Result
 
 **`accounts` (`vec`):** List of ICRC-1 accounts.
 
@@ -120,7 +113,6 @@ must send the `"VERSION_NOT_SUPPORTED"` error in response.
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "version": "1",
     "accounts": [
       {
         "principal": "gyu2j-2ni7o-o6yjt-n7lyh-x3sxq-zh7hp-sjvqe-t7oul-4eehb-2gvtt-jae",
@@ -139,8 +131,6 @@ must send the `"VERSION_NOT_SUPPORTED"` error in response.
 
 1. The relying party sends a `icrc27_get_icrc1_accounts` request to the signer.
 2. Upon receiving the message, the signer first checks if it can process the message.
-    - If the request version is not supported by the signer, the signer sends a response with an error back to the
-      relying party.
     - If the relying party has not been granted the permission to invoke the method for the specified principal, the
       signer sends a response with an error back to the relying party.
 3. The signer MUST always prompt the user to select which ICRC-1 accounts to share with the relying party
@@ -154,10 +144,8 @@ sequenceDiagram
     participant S as Signer
     participant U as User
     RP ->> S: Request ICRC-1 accounts
-    alt Version is not supported
-        S ->> RP: Error response: Version not supported (20101)
-    else Scope `icrc27_get_icrc1_subaccounts` not granted
-        S ->> RP: Error response: Permission not granted (30101)
+    alt Scope `icrc27_get_icrc1_accounts` not granted
+        S ->> RP: Error response: Permission not granted (3000)
     else
         S ->> U: Prompt to select ICRC-1 accounts
         U ->> S: Select ICRC-1 accounts


### PR DESCRIPTION
This PR drop `version` in alignment with #128. The errors are adjusted to that change as well.