### PR TITLE
ICRC-21: Add PaymentRequired error variant

### DIFF
--- a/topics/icrc_21_consent_msg.md
+++ b/topics/icrc_21_consent_msg.md
@@ -106,7 +106,7 @@ type icrc21_error = variant {
     // While small consent messages are easy and cheap to provide, this might not generally be the case for all consent
     // messages. To avoid future breaking changes, when introducing a payment flow, this error is already introduced
     // even though there no standardized payment flow yet.
-    PaymentRequired: icrc21_error_info;
+    InsufficientPayment: icrc21_error_info;
 
     // Any error not covered by the above variants.
     GenericError: record {

--- a/topics/icrc_21_consent_msg.md
+++ b/topics/icrc_21_consent_msg.md
@@ -99,6 +99,14 @@ type icrc21_error = variant {
     //
     // The developer should provide more information about the error using the description in icrc21_error_info.
     ConsentMessageUnavailable: icrc21_error_info;
+    
+    // The canister did not provide a consent message for because payment was missing or insufficient.
+    //
+    // This error is used to account for payment extensions to be added in the future:
+    // While small consent messages are easy and cheap to provide, this might not generally be the case for all consent
+    // messages. To avoid future breaking changes, when introducing a payment flow, this error is already introduced
+    // even though there no standardized payment flow yet.
+    PaymentRequired: icrc21_error_info;
 
     // Any error not covered by the above variants.
     GenericError: record {


### PR DESCRIPTION
This PR future proofs ICRC-21 for the addition of a payment flow to be added later. It is highly likely, that if the consent messages get widely used, that some of them are only provided if they are paid for.

A concrete example of that is the `install_code` method on the management canister: If the provided wasm module is 2MB in size and the consent message is to include the SHA256 of that wasm moduel, empirical measurements have shown that producing such a message costs about 4.5B cycles, which is about $0.006.
If every consent message for all `install_code` calls was provided for free this would incur a significant aggregated cost on the IC as a platform.

While we do not want to introduce a payment flow immediately, we can at least prepare for the eventual introduction of such a flow by adding one additional error variant to the ICRC-21 base standard. This will make payment flow extension a non-breaking enhancement of ICRC-21.