### PR TITLE
Switch supported standards method to ICRC-10

### DIFF
--- a/reference-implementations/ICRC-21/icrc21_reference_canister.did
+++ b/reference-implementations/ICRC-21/icrc21_reference_canister.did
@@ -9,12 +9,12 @@ service : {
     // This is currently an update call. As soon as secure (replicated) query calls are available, this will be changed to such a replicated query call.
     icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
 
-    // Returns a list of supported standards related to consent messages that this canister implements.
-    // The result should always have at least one entry:
+    // Returns a list of supported standards that this canister implements.
+    // The result must include an entry for ICRC-21:
     // record { name = "ICRC-21"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md" }
     //
-    // This query call must not require authentication.
-    icrc21_supported_standards : () -> (vec record { name : text; url : text }) query;
+    // See ICRC-10 for more information: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md
+    icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 
 
     // Returns a greeting message for the given name.

--- a/reference-implementations/ICRC-21/src/lib.rs
+++ b/reference-implementations/ICRC-21/src/lib.rs
@@ -15,11 +15,17 @@ fn greet(name: String) -> String {
 }
 
 #[ic_cdk::query]
-fn icrc21_supported_standards() -> Vec<Icrc21SupportedStandard> {
-    vec![Icrc21SupportedStandard {
-        url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md".to_string(),
-        name: "ICRC-21".to_string(),
-    }]
+fn icrc10_supported_standards() -> Vec<Icrc21SupportedStandard> {
+    vec![
+        Icrc21SupportedStandard {
+            url: "https://github.com/dfinity/ICRCs/ICRC-10.md".to_string(),
+            name: "ICRC-10".to_string(),
+        },
+        Icrc21SupportedStandard {
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md".to_string(),
+            name: "ICRC-21".to_string(),
+        },
+    ]
 }
 
 #[ic_cdk::update]
@@ -160,12 +166,18 @@ mod test {
     #[test]
     fn should_declare_icrc21_support() {
         assert_eq!(
-            icrc21_supported_standards(),
-            vec![Icrc21SupportedStandard {
-                url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md"
-                    .to_string(),
-                name: "ICRC-21".to_string(),
-            }]
+            icrc10_supported_standards(),
+            vec![
+                Icrc21SupportedStandard {
+                    url: "https://github.com/dfinity/ICRCs/ICRC-10.md".to_string(),
+                    name: "ICRC-10".to_string(),
+                },
+                Icrc21SupportedStandard {
+                    url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md"
+                        .to_string(),
+                    name: "ICRC-21".to_string(),
+                }
+            ]
         );
     }
 


### PR DESCRIPTION
Change the icrc21_supported_standards query to
icrc10_supported_standards to be in line with the changes made in #171.