### PR TITLE
ICRC-29: Switch from signer notification to polling

### DIFF
--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -20,17 +20,30 @@ For this standard to represent an [ICRC-25](https://github.com/dfinity/wg-identi
 
 ## Establishing a Communication Channel
 
-A [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) communication channel is initiated by the relying party. The relying party opens a new window and waits for the signer to send a message indicating that it is ready for interactions.
-The message is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) notification with the method `icrc29_ready` and no parameters:
+A [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) communication channel is initiated by the relying party. The relying party opens a new window and polls repeatedly for the signer to reply with a message indicating that it is ready for interactions.
+The message sent by the relaying party is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) call with method `icrc29_status` and no parameters:
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "icrc29_ready"
+    "id": "1",
+    "method": "icrc29_status"
 }
 ```
 
-After this message has been received, the relying party can send [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) messages to the signer
+The signer should reply with a message indicating that it is ready to receive additional messages:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "result": "ready"
+}
+```
+
+> **Note**: The relying party should send `icrc29_status` messages in short intervals. It is expected that some of the messages will be lost due to being sent before the signer is ready.
+
+After the `"result": "ready"` response has been received, the relying party can send [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) messages to the signer
 using the [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API.
 
 ## Authentication


### PR DESCRIPTION
By changing from the notification to polling, the signer no longer relies on the `window.opener` to be available to signal its readiness.

This is allows the signer window to redirect to other domains before signalling ready.