### PR TITLE
ICRC-29 Allow redirect by signer to different origin

### DIFF
--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -32,7 +32,7 @@ The message sent by the relaying party has `targetOrigin` set to `'*'` and is a 
 ```
 
 The signer should reply with a message with indicating that it is ready to receive additional messages.
-The message `targetOrigin` should be set to the `icrc29_status` message its `origin` property value.
+The message `targetOrigin` should be set to the previously received `icrc29_status` message its `origin` property value.
 
 ```json
 {
@@ -44,14 +44,14 @@ The message `targetOrigin` should be set to the `icrc29_status` message its `ori
 
 > **Note**: The relying party should send `icrc29_status` messages in short intervals. It is expected that some of the messages will be lost due to being sent before the signer is ready.
 
-After the `"result": "ready"` response has been received, the relying party can send [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) messages to the signer
+After the `"result": "ready"` response has been received within a reasonable timeframe, the relying party can send [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) messages to the signer
 using the [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API.
 
 ## Authentication
 
 * The relying party must authenticate the signer by checking if both:
   - The received message `source` property is equal to the `window` that was opened.
-  - The received message `origin` property is equal to the `origin` property in the `"result": "ready"` message received when communication channel was established.
+  - The received message `origin` property is equal to the `origin` property in the `"result": "ready"` response received when communication channel was established.
 * The signer must authenticate the relying party by checking if both:
     - The received message `source` property is equal to the `window.opener`.
     - The received message `origin` property is equal to the `origin` property in the `icrc29_status` message received when communication channel was established.
@@ -60,9 +60,9 @@ using the [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/
 
 Messages are sent by calling `window.postMessage` on the signer window, or the `window.opener` respectively.
 
-When sending messages from relying party to signer, the `targetOrigin` parameter must be set to the `origin` property in the `"result": "ready"` message received when communication channel was established
+When sending messages from relying party to signer, the `targetOrigin` parameter must be set to the `origin` property in the `"result": "ready"` response received when the communication channel was established
 
-When sending messages from signer to relying party, the `targetOrigin` parameter must be set to the `origin` property in the `icrc29_status` message received when communication channel was established.
+When sending messages from signer to relying party, the `targetOrigin` parameter must be set to the `origin` property in the `icrc29_status` message received when the communication channel was established.
 
 The relying party may close the signer window in between interactions. If the relying party wants to continue a session after having closed the window, it must again go through the process of [establishing a communication channel](#establishing-a-communication-channel). 
 

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -54,7 +54,7 @@ using the [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/
 ## Sending Messages
 
 Messages are sent by calling `window.postMessage` on the signer window, or the `window.opener` respectively.
-When sending messages from relying party to signer, the `targetOrigin` parameter must be omitted, so that the signer can redirect to a different origin when needed.
+When sending messages from relying party to signer, the `targetOrigin` parameter must be set to `'*'`, so that the signer can redirect to a different origin when needed.
 When sending messages from signer to relying party, the `targetOrigin` parameter must be set to the `origin` property in the previously received `icrc29_status` message event.
 
 The relying party may close the signer window in between interactions. If the relying party wants to continue a session after having closed the window, it must again go through the process of [establishing a communication channel](#establishing-a-communication-channel). 

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -58,7 +58,7 @@ using the [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/
 
 ## Sending Messages
 
-Messages are sent by calling `window.postMessage` on the signer window, or the `message.source` on the message received when communication channel was established respectively.
+Messages are sent by calling `window.postMessage` on the signer `window`, or the `source` property in the `icrc29_status` message received when communication channel was established respectively.
 
 When sending messages from relying party to signer, the `targetOrigin` parameter must be set to the `origin` property in the `"result": "ready"` response received when the communication channel was established
 

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -63,7 +63,7 @@ Instead, the relying party is responsible for closing the signer window.
 
 ## Relying party
 
-The `origin` value of the received message `"result": "ready"` when the communication channel was established,
+The `origin` value of the first received reply to a `icrc29_status` message with `"result": "ready"` when establishing the communication channel,
 is mentioned below as `establishedOrigin`.
 
 The `window` that was opened for the signer is mentioned below as `signerWindow`.

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -74,7 +74,7 @@ Messages are received by listening to `message` events, messages are considered 
 
 Messages are sent by calling the `postMessage` method on the `signerWindow` with the `targetOrigin` parameter set to `establishedOrigin`.
 
-Make sure to call the `close` method on the `signerWindow` after it is no longer needed.  
+The relying party should call the `close` method on the `signerWindow` after it is no longer needed.  
 After having closed the window, the signer must again go through the process of [establishing a communication channel](#establishing-a-communication-channel).
 
 ## Error Handling

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -21,7 +21,7 @@ For this standard to represent an [ICRC-25](https://github.com/dfinity/wg-identi
 ## Establishing a Communication Channel
 
 A [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) communication channel is initiated by the relying party. The relying party opens a new window and polls repeatedly for the signer to reply with a message indicating that it is ready for interactions.
-The message sent by the relaying party has `targetOrigin` set to `'*'` and is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) call with method `icrc29_status` and no parameters:
+The message sent by the relying party has `targetOrigin` set to `'*'` and is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) call with method `icrc29_status` and no parameters:
 
 ```json
 {
@@ -31,7 +31,7 @@ The message sent by the relaying party has `targetOrigin` set to `'*'` and is a 
 }
 ```
 
-The signer should reply with a message with indicating that it is ready to receive additional messages.
+The signer should reply with a message indicating that it is ready to receive additional messages.
 The message `targetOrigin` should be set to the previously received `icrc29_status` message its `origin` property value.
 
 ```json
@@ -53,12 +53,12 @@ using the [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/
   - The received message `source` property is equal to the `window` that was opened.
   - The received message `origin` property is equal to the `origin` property in the `"result": "ready"` response received when communication channel was established.
 * The signer must authenticate the relying party by checking if both:
-    - The received message `source` property is equal to the `window.opener`.
-    - The received message `origin` property is equal to the `origin` property in the `icrc29_status` message received when communication channel was established.
+  - The received message `source` property is equal to the `source` property in the `icrc29_status` message received when communication channel was established.
+  - The received message `origin` property is equal to the `origin` property in the `icrc29_status` message received when communication channel was established.
 
 ## Sending Messages
 
-Messages are sent by calling `window.postMessage` on the signer window, or the `window.opener` respectively.
+Messages are sent by calling `window.postMessage` on the signer window, or the `message.source` on the message received when communication channel was established respectively.
 
 When sending messages from relying party to signer, the `targetOrigin` parameter must be set to the `origin` property in the `"result": "ready"` response received when the communication channel was established
 

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -68,7 +68,7 @@ is mentioned below as `establishedOrigin`.
 
 The `window` that was opened for the signer is mentioned below as `signerWindow`.
 
-Messages are received by listening to `message` events, messages are considered as coming from signer if both:
+Messages are received by listening to `message` events. Messages are considered as coming from signer if both:
 - The received message `origin` property is equal to the `establishedOrigin`.
 - The received message `source` property is equal to the `signerWindow`.
 

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -75,7 +75,7 @@ Messages are received by listening to `message` events, messages are considered 
 Messages are sent by calling the `postMessage` method on the `signerWindow` with the `targetOrigin` parameter set to `establishedOrigin`.
 
 Make sure to call the `close` method on the `signerWindow` after it is no longer needed.  
-After having closed the window, the signer must again go through the process of [establishing a communication channel](#establishing-a-communication-channel) again.
+After having closed the window, the signer must again go through the process of [establishing a communication channel](#establishing-a-communication-channel).
 
 ## Error Handling
 


### PR DESCRIPTION
Updated the spec to allow for redirect by the signer to a different origin. Previously a PR was made to switch to polling to make this possible but e.g. the authentication part in the spec did not allow for a signer origin that changes due to e.g. a redirect.

Also a note has been added regarding closing the signer window.