### PR TITLE
ICRC-21: Add UTC offset to consent message preferences

### DIFF
--- a/reference-implementations/ICRC-21/src/icrc21_types.rs
+++ b/reference-implementations/ICRC-21/src/icrc21_types.rs
@@ -3,6 +3,7 @@ use candid::{self, CandidType, Deserialize};
 #[derive(CandidType, Deserialize, Eq, PartialEq, Debug)]
 pub struct Icrc21ConsentMessageMetadata {
     pub language: String,
+    pub utc_offset_minutes: Option<i16>,
 }
 
 #[derive(CandidType, Deserialize)]

--- a/reference-implementations/ICRC-21/src/lib.rs
+++ b/reference-implementations/ICRC-21/src/lib.rs
@@ -44,9 +44,11 @@ fn icrc21_canister_call_consent_message(
         }));
     };
 
-    // only English supported
     let metadata = Icrc21ConsentMessageMetadata {
+        // only English supported
         language: "en".to_string(),
+        // no time information in the consent message
+        utc_offset_minutes: None,
     };
 
     match consent_msg_request.user_preferences.device_spec {
@@ -189,6 +191,7 @@ mod test {
             user_preferences: Icrc21ConsentMessageSpec {
                 metadata: Icrc21ConsentMessageMetadata {
                     language: "en".to_string(),
+                    utc_offset_minutes: None,
                 },
                 device_spec: Some(GenericDisplay),
             },
@@ -197,7 +200,8 @@ mod test {
             result,
             Icrc21ConsentInfo {
                 metadata: Icrc21ConsentMessageMetadata {
-                    language: "en".to_string()
+                    language: "en".to_string(),
+                    utc_offset_minutes: None,
                 },
                 consent_message: GenericDisplayMessage(
                     "Produce the following greeting text:\n> Hello, Alice!".to_string()
@@ -215,6 +219,7 @@ mod test {
             user_preferences: Icrc21ConsentMessageSpec {
                 metadata: Icrc21ConsentMessageMetadata {
                     language: "en".to_string(),
+                    utc_offset_minutes: None,
                 },
                 device_spec: Some(LineDisplay {
                     characters_per_line: 20,
@@ -226,7 +231,8 @@ mod test {
             result,
             Icrc21ConsentInfo {
                 metadata: Icrc21ConsentMessageMetadata {
-                    language: "en".to_string()
+                    language: "en".to_string(),
+                    utc_offset_minutes: None,
                 },
                 consent_message: LineDisplayMessage {
                     pages: vec![

--- a/topics/ICRC-21/ICRC-21.did
+++ b/topics/ICRC-21/ICRC-21.did
@@ -4,6 +4,13 @@
 type icrc21_consent_message_metadata = record {
     // BCP-47 language tag. See https://www.rfc-editor.org/rfc/bcp/bcp47.txt
     language: text;
+
+    // The users local timezone offset in minutes from UTC.
+    // Applicable when converting timestamps to human-readable format.
+    //
+    // If absent in the request, the canister should fallback to the UTC timezone when creating the consent message.
+    // If absent in the response, the canister is indicating that the consent message is not timezone sensitive.
+    utc_offset_minutes: opt int16;
 };
 
 type icrc21_consent_message_spec = record {


### PR DESCRIPTION
In the ongoing implementation of consent messages in the ledger canisters timezone conversion was raised as an issue.

An optional UTC offset is added to the consent message metadata to address that requirement.