### PR TITLE
ICRC-25: Change permission model to support ask-on-(first-)use

### DIFF
--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -140,12 +140,11 @@ While processing the request from the relying party, the signer can cancel it at
 
 1. The relying party sends a `icrc25_request_permissions` message to the signer.
 2. The signer removes any unrecognized scopes from the array of requested scopes.
-3. The signer displays the requested scopes to the user and asks the user to approve or reject the request. The user may also be allowed to approve only a subset of the requested scopes or add additional restrictions (see [extension scope properties](#extension-properties)).
+3. The signer displays the requested scopes to the user and ask the user to confirm or reject the scope state changes. The user may be allowed to only confirm a subset of the requested changes and make further (or different) modifications to the suggested ones (including adding restrictions to scopes with [extension properties](#extension-properties)).
     - If all requested scopes have already been granted, the signer may skip the user interaction.
     - If, by signer policy, the requested changes cannot be granted (e.g. because the signer enforces `ask_on_use` for specific permission scopes), the signer may skip the user interaction. 
-    - If the user approves the request, the signer saves the changes to the permission scopes, including modifications made by the user (if any).
-    - If the user rejects the request then no changes are made to the permission scopes.
-4. The signer sends a response to the relying party with the state of each permission scope.
+4. The signer saves the changes to the permission scopes (if any), including modifications made by the user.
+5. The signer sends a response to the relying party with the state of each permission scope.
 
 ```mermaid
 sequenceDiagram

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -144,7 +144,7 @@ While processing the request from the relying party, the signer can cancel it at
     - If all requested scopes have already been granted, the signer may skip the user interaction.
     - If, by signer policy, the requested changes cannot be granted (e.g. because the signer enforces `ask_on_use` for specific permission scopes), the signer may skip the user interaction. 
 4. The signer saves the changes to the permission scopes (if any), including modifications made by the user.
-5. The signer sends a response to the relying party with the state of each permission scope, including _all_ permission scopes and not only the ones changed in processing this request.
+5. The signer sends a response to the relying party with the state of all permission scopes.
 
 ```mermaid
 sequenceDiagram
@@ -230,7 +230,7 @@ While processing the request from the relying party, the signer can cancel it at
 #### Message Processing
 
 1. The relying party sends a `icrc25_granted_permissions` message to the signer.
-2. The signer replies with the state of each [permission scopes](#permissions) for the relying party.
+2. The signer replies with the state of all [permission scopes](#permissions) for the relying party.
 
 ```mermaid
 sequenceDiagram

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -102,7 +102,7 @@ to further restrict the scope, for example, by specifying the canister ID or the
 
 This standard is the signer interaction _base_ standard. As such it intentionally excludes all methods that could be handled by an extension, for example:
 
-- Getting accounts: [ICRC-27](./icrc_27_get_accounts.md)
+- Getting accounts: [ICRC-27](./icrc_27_accounts.md)
 - Canister calls: [ICRC-49](./icrc_49_call_canister.md)
 
 This allows signer developers to choose which extensions they want to support and only implement those.
@@ -144,7 +144,7 @@ While processing the request from the relying party, the signer can cancel it at
     - If all requested scopes have already been granted, the signer may skip the user interaction.
     - If, by signer policy, the requested changes cannot be granted (e.g. because the signer enforces `ask_on_use` for specific permission scopes), the signer may skip the user interaction. 
 4. The signer saves the changes to the permission scopes (if any), including modifications made by the user.
-5. The signer sends a response to the relying party with the state of each permission scope.
+5. The signer sends a response to the relying party with the state of each permission scope, including _all_ permission scopes and not only the ones changed in processing this request.
 
 ```mermaid
 sequenceDiagram
@@ -170,7 +170,7 @@ Request
     "params": {
         "scopes": [
             {
-                "method": "icrc27_get_accounts"
+                "method": "icrc27_accounts"
             },
             {
                 "method": "icrc49_call_canister"
@@ -189,7 +189,7 @@ Response
         "scopes": [
             {
                 "scope": {
-                    "method": "icrc27_get_accounts"
+                    "method": "icrc27_accounts"
                 },
                 "state": "granted"
             },
@@ -230,7 +230,7 @@ While processing the request from the relying party, the signer can cancel it at
 #### Message Processing
 
 1. The relying party sends a `icrc25_granted_permissions` message to the signer.
-2. The signer replies with the state of every [permission scopes](#permissions) for the relying party.
+2. The signer replies with the state of each [permission scopes](#permissions) for the relying party.
 
 ```mermaid
 sequenceDiagram
@@ -262,7 +262,7 @@ Response
         "scopes": [
             {
                 "scope": {
-                    "method": "icrc27_get_accounts"
+                    "method": "icrc27_accounts"
                 },
                 "state": "granted"
             },

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -143,8 +143,8 @@ While processing the request from the relying party, the signer can cancel it at
 3. The signer displays the requested scopes to the user and ask the user to confirm or reject the scope state changes. The user may be allowed to only confirm a subset of the requested changes and make further (or different) modifications to the suggested ones (including adding restrictions to scopes with [extension properties](#extension-properties)).
     - If all requested scopes have already been granted, the signer may skip the user interaction.
     - If, by signer policy, the requested changes cannot be granted (e.g. because the signer enforces `ask_on_use` for specific permission scopes), the signer may skip the user interaction. 
-4. The signer saves the changes to the permission scopes (if any), including modifications made by the user.
-5. The signer sends a response to the relying party with the state of all permission scopes.
+4. The signer saves the changes to the permission scopes (if any), including modifications made by the user. 
+5. The signer replies with the state of all [permission scopes](#permissions) for the specific relying party.
 
 ```mermaid
 sequenceDiagram
@@ -230,7 +230,7 @@ While processing the request from the relying party, the signer can cancel it at
 #### Message Processing
 
 1. The relying party sends a `icrc25_granted_permissions` message to the signer.
-2. The signer replies with the state of all [permission scopes](#permissions) for the relying party.
+2. The signer replies with the state of all [permission scopes](#permissions) for the specific relying party.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
This PR makes significant changes to the ICRC-25 permission model:
* The notion of a session has been removed. The state of permissions is considered permanent with respect to a specific relying party (subject to signer policy). This closes the gap between stateless and stateful signers.
* Permissions can now be requested implicitly by simply making use of a method, given the permission has not been explicitly denied before.
* `icrc25_revoke_permissions` has been removed as it is no longer applicable to the current permission model. Resetting permissions has been considered, but dismissed as relying parties could request denied permissions to be reset too (or, in case that is excluded, would lead to unintuitive API design).
* `icrc25_granted_permissions` has been changed to `icrc25_permissions` as it now returns information about the state of all permission scopes (including denied ones).
* `icrc25_request_permissions` has been simplified and now is explicitly intended to request the state of a permission scope to be set to `granted`. Furthermore, the response to this request is now consistent with the response to `icrc25_permissions` making the API easier to use.
* The section on permissions has been restructured in an attempt to make it easier to understand.
* Scope extension properties have been properly defined.