### PR TITLE
ICRC-27, ICRC-49: Remove active session prerequisite

### DIFF
--- a/topics/icrc_27_accounts.md
+++ b/topics/icrc_27_accounts.md
@@ -28,7 +28,7 @@ managed by the signer.
 
 **Name:** `icrc27_accounts`
 
-**Prerequisite:** Active session with granted permission scope `icrc27_accounts`.
+**Prerequisite:** Granted permission scope `icrc27_accounts`.
 
 ## Scope (according to the [ICRC-25 standard](./icrc_25_signer_interaction_standard.md))
 

--- a/topics/icrc_49_call_canister.md
+++ b/topics/icrc_49_call_canister.md
@@ -26,7 +26,7 @@ This Method can be used by the relying party to request calls to 3rd party canis
 
 **Name:** `icrc49_call_canister`
 
-**Prerequisite:** Active session with granted permission scope `icrc49_call_canister`.
+**Prerequisite:** Granted permission scope `icrc49_call_canister`.
 
 ## Scope (according to the [ICRC-25 standard](./icrc_25_signer_interaction_standard.md))
 


### PR DESCRIPTION
Since the ICRC-25 rework in #185 there is no longer a concept of session. Hence the prerequisites in ICRC-27 and ICRC-49 need to be adjusted.