### PR TITLE
docs: update wg approved status badges

### DIFF
--- a/topics/ICRC-21/icrc_21_consent_msg.md
+++ b/topics/ICRC-21/icrc_21_consent_msg.md
@@ -1,10 +1,6 @@
 # ICRC-21: Canister Call Consent Messages
 
-
-| Status |
-|:------:|
-| Draft  |
-
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 
 ## Summary
 This specification describes a protocol for obtaining human-readable consent messages for canister calls. These messages are intended to be shown to users to help them make informed decisions about whether to approve a canister call / sign a transaction.

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -1,6 +1,6 @@
 # ICRC-25: Signer Interaction Standard
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 
 <!-- TOC -->
 * [ICRC-25: Signer Interaction Standard](#icrc-25-signer-interaction-standard)

--- a/topics/icrc_27_accounts.md
+++ b/topics/icrc_27_accounts.md
@@ -1,6 +1,6 @@
 # ICRC-27: Get Accounts
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 [![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
 
 <!-- TOC -->

--- a/topics/icrc_28_trusted_origins.md
+++ b/topics/icrc_28_trusted_origins.md
@@ -1,6 +1,6 @@
 # ICRC-28: Trusted Origins
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 [![Standard Issue](https://img.shields.io/badge/ISSUE-ICRC--28-blue?logo=github)](https://github.com/dfinity/wg-identity-authentication/issues/115)
 
 <!-- TOC -->

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -1,8 +1,6 @@
 # ICRC-29: Window Post Message Transport for ICRC-25
 
-| Status |
-|:------:|
-| Draft  |
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 
 ## Summary
 

--- a/topics/icrc_34_delegation.md
+++ b/topics/icrc_34_delegation.md
@@ -1,6 +1,6 @@
 # ICRC-34: Delegation
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 [![Extension Badge](https://img.shields.io/badge/EXTENDS-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
 [![Standard Issue](https://img.shields.io/badge/ISSUE-ICRC--34-blue?logo=github)](https://github.com/dfinity/wg-identity-authentication/issues/115)
 

--- a/topics/icrc_49_call_canister.md
+++ b/topics/icrc_49_call_canister.md
@@ -1,6 +1,6 @@
 # ICRC-49: Call Canister
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
+[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
 [![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
 
 <!-- TOC -->


### PR DESCRIPTION
Few standards have been approved by the WG, marked as such on the README but their respective badges weren't updated.