### PR TITLE
docs: fix link to icrc-21

### DIFF
--- a/topics/icrc_49_call_canister.md
+++ b/topics/icrc_49_call_canister.md
@@ -109,7 +109,7 @@ An ICRC-25 compliant signer must implement the [icrc25_supported_standards](./ic
     - If the relying party has been denied the permission to invoke the method,
       the signer sends a response with an error back to the relying party.
       If the permission state is `ask_on_use`, the signer must prompt the user to either accept or deny this invocation. See [permission states](icrc_25_signer_interaction_standard.md#permissions-states) for more details.
-3. The signer tries to retrieve and verify the consent message according to the [ICRC-21](icrc_21_consent_msg.md) specification. If the target canister does not support ICRC-21 consent messages for the given canister call, the signer may proceed in one of following ways:
+3. The signer tries to retrieve and verify the consent message according to the [ICRC-21](ICRC-21/icrc_21_consent_msg.md) specification. If the target canister does not support ICRC-21 consent messages for the given canister call, the signer may proceed in one of following ways:
    * The signer rejects the request and sends a response with the error code 2001 back to the relying party. Step 4 is skipped.
    * The signer displays a warning, tries to decode the arguments by itself and displays raw canister call details. If the arguments cannot be decoded, a strong warning must be displayed.
       > **Note:** Signing canister calls without an ICRC-21 consent message is dangerous! Signing canister calls solely based on the decoded arguments might yield unexpected results. Strong technical knowledge is required to understand the consequences of such actions. Blind signing of canister calls (without even decoding the arguments) is not recommended and requires complete trust in the relying party.


### PR DESCRIPTION
I spotted an invalid link in ICRC-49 to ICRC-21. I guess the latest was maved but, the link was not updated.