### PR TITLE
[Draft] [ICRC X] Content type of consent message

### DIFF
--- a/topics/ICRC-X/ICRC-X.did
+++ b/topics/ICRC-X/ICRC-X.did
@@ -1,0 +1,142 @@
+
+type icrc21_consent_message_metadata = record {
+    // BCP-47 language tag. See https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+    language: text;
+
+    // The users local timezone offset in minutes from UTC.
+    // Applicable when converting timestamps to human-readable format.
+    //
+    // If absent in the request, the canister should fallback to the UTC timezone when creating the consent message.
+    // If absent in the response, the canister is indicating that the consent message is not timezone sensitive.
+    utc_offset_minutes: opt int16;
+};
+
+type icrc21_consent_message_spec = record {
+    // BCP-47 language tag. See https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+    language: text;
+
+    // The users local timezone offset in minutes from UTC.
+    // Applicable when converting timestamps to human-readable format.
+    //
+    // If absent in the request, the canister should fallback to the UTC timezone when creating the consent message.
+    // If absent in the response, the canister is indicating that the consent message is not timezone sensitive.
+    utc_offset_minutes: opt int16;
+};
+
+// This inherit from ICRC 21 
+type icrcX_consent_message_request = record {
+    // Method name of the canister call.
+    method: text;
+    // Argument of the canister call.
+    arg: blob;
+    // User preferences with regards to the consent message presented to the end-user.
+    user_preferences: icrc21_consent_message_spec;
+    // Content type of the consent message.
+    content_type: text;
+};
+
+type icrcX_consent_message = variant {
+    // Message for a generic display able to handle large documents and do proper line wrapping and pagination / scrolling.
+    // Uses Markdown formatting, no external resources (e.g. images) are allowed.
+    GenericDisplayMessage: text;
+};
+
+
+type icrc21_consent_info = record {
+    // Consent message describing in a human-readable format what the call will do.
+    //
+    // The message should adhere as close as possible to the user_preferences specified in the consent_message_spec + format in content_type
+    // of the icrcX_consent_message_request.
+    // If the message is not available for the given user_preferences any fallback message should be used. Providing a
+    // message should be preferred over sending an icrc21_error.
+    // The metadata must match the consent_message provided.
+    //
+    // The message should be short and concise.
+    // It should only contain information that is:
+    // * relevant to the user
+    // * relevant given the canister call argument
+    // * formatted in valid content_type provided in the request
+    // Example with "content_type" : "application/json"
+    // {
+    //     "message": "This call will transfer 100 tokens from your account to the recipient account.",
+    //     "assetIn" : [
+    //                      {"address": "0x1234", "amount": 100}],     
+    //                  ]
+    //     "assetOut" : [
+    //                      {"address": "0x1234", "amount": 100}],
+    //                  ]   
+    //      "to": "0x1234",
+    //      "from": "0x1234",
+    //      "fee": 100,
+    // }
+    consent_message: icrcX_consent_message;
+    // Metadata of the consent_message.
+    metadata: icrc21_consent_message_metadata;
+
+};
+
+type icrc21_error_info = record {
+    // Human readable technical description of the error intended for developers, not the end-user.
+    description: text;
+};
+
+type icrcX_error = variant {
+    // The canister does not support this call (i.e. it will lead to a rejection or error response).
+    // Reasons might be (non-exhaustive list):
+    // * the canister call is malformed (e.g. wrong method name, argument cannot be decoded)
+    // * the arguments exceed certain bounds
+    //
+    // The developer should provide more information about the error using the description in icrc21_error_info.
+    UnsupportedCanisterCall: icrc21_error_info;
+
+    // The canister cannot produce a consent message for this call.
+    // Reasons might be (non-exhaustive list):
+    // * it is an internal call not intended for end-users
+    // * the canister developer has not yet implemented a consent message for this call
+    //
+    // The developer should provide more information about the error using the description in icrc21_error_info.
+    ConsentMessageUnavailable: icrc21_error_info;
+
+    // The canister did not provide a consent message for because payment was missing or insufficient.
+    //
+    // This error is used to account for payment extensions to be added in the future:
+    // While small consent messages are easy and cheap to provide, this might not generally be the case for all consent
+    // messages. To avoid future breaking changes, when introducing a payment flow, this error is already introduced
+    // even though there no standardized payment flow yet.
+    InsufficientPayment: icrc21_error_info;
+
+    // The content type of the consent message is not supported.
+    NotSupportedContentType: icrc21_error_info;
+
+    // Any error not covered by the above variants.
+    GenericError: record {
+       // Machine parsable error. Can be chosen by the target canister but should indicate the error category.
+       error_code: nat;
+       // Human readable technical description of the error intended for developers, not the end-user.
+       description: text;
+   };
+};
+
+type icrc21_consent_message_response = variant {
+    // The call is ok, consent message is provided.
+    Ok: icrc21_consent_info;
+    // The call is not ok, error is provided.
+    Err: icrc21_error;
+};
+
+service : {
+    // Returns a human-readable consent message for the given canister call.
+    //
+    // This call must not require authentication (i.e. must be available for the anonymous sender).
+    // If the call is made with a non-anonymous identity, the response may be tailored to the identity.
+    //
+    // This is currently an update call. As soon as secure (replicated) query calls are available, this will be changed to such a replicated query call.
+    icrcX_canister_call_consent_message: (icrcX_consent_message_request) -> (icrc21_consent_message_response);
+
+    // Returns a list of supported standards that this canister implements.
+    // The result must include an entry for ICRC-21:
+    // record { name = "ICRC-21"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md" }
+    //
+    // See ICRC-10 for more information: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md
+    icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+}

--- a/topics/ICRC-X/icrc_X_asset_in_out_consent_message.md
+++ b/topics/ICRC-X/icrc_X_asset_in_out_consent_message.md
@@ -5,8 +5,7 @@
 ## Summary
 
 This specification describes a protocol for content return by request consent message
-
-This specification inherited funtionalities from ICRC_21 standard
+This specification inherited functionalities from ICRC_21 standard
 
 ## Terminology
 

--- a/topics/ICRC-X/icrc_X_asset_in_out_consent_message.md
+++ b/topics/ICRC-X/icrc_X_asset_in_out_consent_message.md
@@ -1,0 +1,120 @@
+# ICRC-X: Content type for consent message
+
+[Draft]
+
+## Summary
+
+This specification describes a protocol for content return by request consent message
+
+This specification inherited funtionalities from ICRC_21 standard
+
+## Terminology
+
+- signer: a service that manages the keys of a user and can sign canister calls on their behalf. This component displays the consent message to the user. The signer may be split in a hot (with connection to the IC) and cold (offline) component.
+- relying party: the service that requests a signature on a specific canister call.
+- target canister: the canister that is the target of the canister call.
+
+## Motivation
+
+ICRC-21 is great but it only support plain text or markdown text. But in blockchain there is some consent message need complicated schema than just a text
+
+## Assumptions
+
+- The signer is trusted by the user.
+- The relying party is _not_ trusted and might be malicious.
+- The target canister is trusted by the user. Interactions with malicious canisters are not covered by this specification. In particular, interacting with a malicious canister can produce arbitrary outcomes regardless of how user consent was collected.
+
+## Canister Call Consent Message Interface
+
+The interface specified in [ICRC-X.did](./ICRC-X.did) must be implemented to support canister call consent messages.
+In addition to implementing this interface, it is recommended that the canister also provides its full candid interface in the public `candid:service` metadata section, as discussed [here](https://forum.dfinity.org/t/rfc-canister-metadata-standard). This is required to properly decode the arguments if the signer also wants to display technical information about the canister call.
+
+### Authentication
+
+The signer may send the `icrc21_consent_message` call using the same identity as it would for the actual canister call for which the consent message was issued.
+
+Any canister implementing the `icrc21_consent_message` interface must not require authentication for this call. Anonymous consent messages are required in the [cold signer use-case](#cold-signer-use-case) which would otherwise require two interactions with the cold signer component, making the flow very cumbersome for users.
+
+Canisters may add additional or different information if a non-anonymous `sender` is used.
+For example, a canister might include private information in the consent message, if the call is made by the owner of that information.
+
+> **_WARNING:_** Canister developers must take care to not rely on the current state of the canister / identity attached data when issuing the consent message. There might be a significant time delay (depending on the signer used) between retrieving the consent message and submitting the canister call. The consent message must accurately describe all possible outcomes of the canister call, accounting for that time delay.
+
+> **_NOTE:_** The `icrc21_consent_message` method is currently declared as an `update` call, due to the necessity
+> of supporting dynamic data in a secure way. As soon as secure (replicated) query calls are available, this will be changed to such a replicated query call.
+
+## Use-Cases
+
+The canister called need return a other content type rather than a normal text
+
+### Consent Message Request
+
+Argument for the ledger canister call to `transfer`:
+
+```
+(
+  record {
+    to = blob "ed2182...";
+    fee = record { e8s = 10_000 : nat64 };
+    memo = 123 : nat64;
+    from_subaccount = null;
+    created_at_time = null;
+    amount = record { e8s = 789_123_000 : nat64 };
+  },
+)
+```
+
+Argument for the ledger canister call to `icrc21_consent_message`:
+
+```
+(
+   record {
+      method = "transfer";
+      arg = blob "4449..."; // candid encoded argument
+      user_preferences = record {
+        language = "en-US"
+      };
+      content_type: "application/json";
+   }
+)
+```
+
+### Consent Message Response
+
+```
+(
+   variant {
+      Ok = record {
+         consent_message = "{"message":"This call will transfer 100 tokens from your account to the recipient account.","assetIn":[{"address":"0x1234","amount":100}],"assetOut":[{"address":"0x1234","amount":100}],"to":"0x1234","from":"0x1234","fee":100}";
+         metadata: record {
+            language = "en-US";
+         }
+      }
+   }
+)
+```
+
+### Signer UI Approval Screen
+
+The message will then be returned to the client in the following context:
+
+```
+{
+  "message": "This call will transfer 100 tokens from your account to the recipient account.",
+  "assetIn": [
+    {
+      "address": "0x1234",
+      "amount": 100
+    }
+  ],
+  "assetOut": [
+    {
+      "address": "0x1234",
+      "amount": 100
+    }
+  ],
+  "to": "0x1234",
+  "from": "0x1234",
+  "fee": 100
+}
+```


### PR DESCRIPTION
- This specification inherited functionalities from ICRC_21 standard 
- This specification return the consent message based on request and support by the canister