### PR TITLE
Overhaul readme, overview, status badges and authors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,183 @@
 # Identity and Wallet Standards
 
 ## Mission Statement
-This group works towards the development and adoption of ICRC standards related to identity and wallets on the Internet Computer. This repository is used to collaborate, document decisions, discuss changes, raise issues and provide feedback.
 
-## Topics
+This group works towards the development and adoption of ICRC standards related to identity and wallets on the Internet
+Computer. This repository is used to collaborate, document decisions, discuss changes, raise issues and provide
+feedback.
 
-| Standard                                                                                                          | Topic                                                                                                                                                             | Lead                                                             | Status                                                                                                                     | Links                                                                                                                                      |
-|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| ICRC-#                                                                                                            | Verifiable Credentials and Presentations                                                                                                                          | [Bartosz Przydatek](https://github.com/przydatek)                | Reference Implementation<br>(MVP impelementation in II, spec will be finalized after)                                      | [w3c Verifiable Credentials](https://www.w3.org/TR/vc-data-model/)                                                                         |
-| [ICRC-21](./topics/ICRC-21/icrc_21_consent_msg.md)                                                                | Canister Call Consent Messages                                                                                                                                    | [Frederik Rothenberger](https://github.com/frederikrothenberger) | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31) | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-25](./topics/icrc_25_signer_interaction_standard.md)                                                        | Signer Interaction Standard                                                                                                                                       | [Frederik Rothenberger](https://github.com/frederikrothenberger)         | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-27](./topics/icrc_27_accounts.md)                                                                       | Accounts<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)                      | [sea-snake](https://github.com/sea-snake)                        | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-28](./topics/icrc_28_trusted_origins.md)                                                                    | Trusted Origins                                                                                                                                          | [Dan Ostrovsky](https://github.com/dostro)                        | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)       |                                                                                                                                            |
-| [ICRC-29](./topics/icrc_29_window_post_message_transport.md)                                                      | Window Post Message Transport<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md) | [Frederik Rothenberger](https://github.com/frederikrothenberger) | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| ICRC-31                                                                                                           | Get Principals<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)                | [Philipp Litzenberger](https://github.com/plitzenberger)         | [![Status Badge](https://img.shields.io/badge/SUPERSEDED-ICRC--27-222.svg)](https://github.com/orgs/dfinity/projects/31)   |                                                                                                                       |
-| [ICRC-32](./topics/icrc_32_sign_challenge.md)                                                                     | Sign Challenge<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)                | [Philipp Litzenberger](https://github.com/plitzenberger)         | [![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-34](./topics/icrc_34_delegation.md)                                                              | Delegation<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)         | [Dan Ostrovsky](https://github.com/dostro)          | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-35](./topics/icrc_35_webpage_apis.md)                                                                       | Browser-Based Interoperability Framework                                                                                                                          | [Sasha Vtyurin](https://github.com/seniorjoinu)                  | [![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)       |                                                                                                                                            |
-| [ICRC-39](./topics/icrc_39_batch_calling.md)                                                                      | Batch Calling<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)                 | [Frederik Rothenberger](https://github.com/frederikrothenberger) | [![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-49](./topics/icrc_49_call_canister.md)                                                                      | Call Canister<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)                 | [Frederik Rothenberger](https://github.com/frederikrothenberger) | [![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| ICRC-57                                              | Get Session Delegation<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)        | [Philipp Litzenberger](https://github.com/plitzenberger)          | [![Status Badge](https://img.shields.io/badge/SUPERSEDED-ICRC--34-222.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-94](./topics/icrc_94_multi_injected_provider_discovery.md)                                                | Multi Injected Provider Discovery<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)        | [sea-snake](https://github.com/sea-snake)          | [![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-95](./topics/icrc_95_derivationorigin.md)                                              | derivationOrigin<br>[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./topics/icrc_25_signer_interaction_standard.md)        | [Dan Ostrovsky](https://github.com/dostro)          | [![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)       | [Signer Standards Overview](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/signer_standards_overview.md)           |
-| [ICRC-#]((https://github.com/dfinity/wg-identity-authentication/issues/26) )                                      | DID registry                                                                                                                                                      | [Quint Daenen](https://github.com/q-uint)                        | [![Status Badge](https://img.shields.io/badge/STATUS-ISSUE-blue.svg)](https://github.com/orgs/dfinity/projects/31)         | [w3c DID registries](https://www.w3.org/TR/did-spec-registries/)                                                                           |
-| [CAIP-2](https://github.com/icvc/icp-namespace/pull/1)<br>[CAIP-10](https://github.com/icvc/icp-namespace/pull/2) | CAIP Specifications                                                                                                                                               | [Quint Daenen](https://github.com/q-uint)                        | [![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)       | [Issue 25](https://github.com/dfinity/wg-identity-authentication/issues/25), [CAIP Specifications](https://github.com/ChainAgnostic/CAIPs) |
+## Terminology
 
-A status overview of the standards owned by this working group can be found [here](https://github.com/orgs/dfinity/projects/31/views/1).
+The following terminology is used across standards within this working group:
+
+- **signer**: A service that manages a user's keys and can sign and perform canister calls on their behalf.
+- **relying party**: A service that wants to interact with a signer e.g. to request calls on a specific canister.
 
 ## Process
-| Status                   | Description                                                                                                              |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| Issue                    | Propose a topic as an issue                                                                                              |
-| Draft Standard           | Write a draft of the final standard                                                                                      |
-| Reference Implementation | Build a reference implementation applying the standard in a practical scenario                                           |
-| Approved Spec            | Agree on solution design in the working group, which should represent the industry (sign off from X people in the group) |
-| Community Approval       | Socialize spec (sign off from Y people in the community, including)                                                      |
-| Standard                 | ICRC Standard                                                                                                            |
+
+The following process is followed for standards within this working group.
+
+If you have a good idea or a need for a standard, feel free join a meeting or bring it up on the [forum][FORUM]
+or [Discord][DISCORD].
+
+Keep in mind it should be related to Identity and/or Wallets built on the IC to be picked up. In case you have other
+ideas, still feel free to reach out, we'll try to help you find the right working group.
+
+These ideas are then translated into the draft standards by their original contributor and/or with help of members
+within this working group. Draft standards enable developers to create early reference implementations.
+
+Approved standards are actively being implemented by developers and are candidates for an official ICRC standard once
+adoption has reached an adequate level.
+
+| Status        | Description                                       |
+|---------------|---------------------------------------------------|
+| ![IDEA]       | Ongoing idea in meetings, on the forum or Discord |
+| ![ISSUE]      | Topic is under discussion in either issue or PR   |
+| ![DRAFT]      | Draft of the final standard, subject to change    |
+| ![APPROVED]   | Approved standard within the working group        |
+| ![STANDARD]   | Official NNS approved ICRC Standard               |
+| ![ON HOLD]    | Waiting to be picked up again once prioritized    |
+| ![UNKNOWN]    | Hasn't progressed and/or had updates for a while  |
+| ![ABANDONED]  | Abandoned and is no longer actively pursued       |
+| ![SUPERSEDED] | Another standard has replaced this standard       |
+
+## Standards
+
+Before jumping into the standards, it's recommended to read the overview [here](./topics/signer_standards_overview.md).
+
+### JSON-RPC Messages
+
+Standards that describe interactions between relying parties and signers with JSON-RPC messages.
+
+| Standard                                                                                      | Status      |
+|-----------------------------------------------------------------------------------------------|-------------|
+| [ICRC-25: Signer Interaction](./topics/icrc_25_signer_interaction_standard.md)                | ![APPROVED] |
+| [ICRC-27: Accounts](./topics/icrc_27_accounts.md)                                             | ![APPROVED] |
+| [ICRC-34: Delegation](./topics/icrc_34_delegation.md)                                         | ![APPROVED] |
+| [ICRC-49: Call Canister](./topics/icrc_49_call_canister.md)                                   | ![APPROVED] |
+| [ICRC-95: Derivation Origin](./topics/icrc_95_derivationorigin.md)                            | ![APPROVED] |
+| [ICRC-#: Batch Call Canister](https://github.com/dfinity/wg-identity-authentication/pull/220) | ![ISSUE]    |
+
+### Transport Channel
+
+Standards that describe how the communication channel between a relying party and signer is established.
+
+| Standard                                                                                                    | Status      |
+|-------------------------------------------------------------------------------------------------------------|-------------|
+| [ICRC-29: Browser Post Message Transport](./topics/icrc_29_window_post_message_transport.md)                | ![APPROVED] |
+| [ICRC-94: Browser Extension Discovery and Transport](./topics/icrc_94_multi_injected_provider_discovery.md) | ![DRAFT]    |
+| ICRC-#: Browser URL Transport                                                                               | ![IDEA]     |
+| ICRC-#: Wallet Connect Transport                                                                            | ![IDEA]     |
+| ICRC-#: Browser Web Signer Discovery                                                                        | ![IDEA]     |
+
+### Canister Calls
+
+Standards that describe canister call interfaces used by signers.
+
+| Standard                                                                                           | Status      |
+|----------------------------------------------------------------------------------------------------|-------------|
+| [ICRC-21: Canister Call Consent Messages](./topics/ICRC-21/icrc_21_consent_msg.md)                 | ![APPROVED] |
+| [ICRC-28: Trusted Origins](./topics/icrc_28_trusted_origins.md)                                    | ![APPROVED] |
+| [ICRC-#: Dapp Metadata Registry](https://github.com/dfinity/wg-identity-authentication/issues/156) | ![ISSUE]    |
+
+### Other
+
+Standards that are currently not actively being pursued, abandoned or superseded.
+
+| Standard                                                                                | Status        | Note                                                                                                                                                                          |
+|-----------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [ICRC-32: Sign Challenge](./topics/icrc_32_sign_challenge.md)                           | ![ON HOLD]    | De-prioritized to focus on IC use cases first                                                                                                                                 |
+| [ICRC-#: DID Registry](https://github.com/dfinity/wg-identity-authentication/issues/26) | ![ON HOLD]    | Feel like picking this up? Contact the working group                                                                                                                          |
+| [ICRC-#: CAIP-2 Blockhain ID](https://github.com/icvc/icp-namespace/pull/1)             | ![ON HOLD]    | Overlaps with work in NFT, Ledger & Tokenization working groups on [ICRC-91](https://github.com/dfinity/ICRC/pull/96) and [ICRC-22](https://github.com/dfinity/ICRC/pull/101) |
+| [ICRC-#: CAIP-10 Account Address](https://github.com/icvc/icp-namespace/pull/2)         | ![ON HOLD]    | Overlaps with work in NFT, Ledger & Tokenization working groups on [ICRC-91](https://github.com/dfinity/ICRC/pull/96) and [ICRC-22](https://github.com/dfinity/ICRC/pull/101) |
+| [ICRC-35: Browser-Based Interoperability Framework](./topics/icrc_35_webpage_apis.md)   | ![UNKNOWN]    | Hasn't received updates for a while                                                                                                                                           |
+| ICRC-31: Get Principals                                                                 | ![SUPERSEDED] | See [ICRC-27: Signer Accounts](./topics/icrc_27_accounts.md)                                                                                                                  |
+| ICRC-57: Get Session Delegation                                                         | ![SUPERSEDED] | See [ICRC-34: Delegation](./topics/icrc_34_delegation.md)                                                                                                                     |
 
 ## Meetings
 
-Meetings happen every two weeks. All meeting recordings can be found [this google folder](https://drive.google.com/drive/folders/14unuYLiYtUeOw47eRwYnB4FCa9YPr6zv).
+Meetings happen every two weeks. All meeting schedule announcements and summaries with links to recordings can be found
+in [this forum thread][FORUM].
 
-Please consult the [working group calendar](https://calendar.google.com/calendar/u/0?cid=Y19jZ29lcTkxN3JwZWFwN3ZzZTNpczFobDMxMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) ([browser view](https://calendar.google.com/calendar/embed?src=c_cgoeq917rpeap7vse3is1hl310%40group.calendar.google.com&ctz=Europe%2FZurich)) for the next meeting date.
+All meeting recordings can be found in [this Google Drive folder][RECORDINGS]. See
+the [working group calendar][CALENDAR] for the next meeting date and the dates of other working groups.
 
-We also have a discord channel for the working group. Please join the [Identity and Wallet Standards](https://discord.gg/pgsR7ksV) channel.
+Besides above forum thread, we also have a [discord channel][DISCORD] for the working group.
 
 ## Contributing
 
 Everyone is welcome to join the public meetings of the working group.
-* If you want to discuss a specific topic, please create and issue or pull-request. We will go over all the newly created issues and PRs in the next meeting.
-* If you own a cool project related to Identity and built on the IC you are welcome to do a presentation in one of the meetings. If you wish to do so, please open an issue and include information about your presentation (title, short summary and estimated time required). 
+
+Additionally, you can also join the discussion on the [forum][FORUM] or [Discord][DISCORD].
+
+* If you want to discuss a specific topic for the next meeting, bring up the topic on the [forum][FORUM]
+  or [Discord][DISCORD]. Additionally consider already creating an issue or pull-request.
+* If you own a cool project related to Identity and/or Wallets built on the IC you are welcome to do a presentation in
+  one of the meetings, please bring it up on the [forum][FORUM] or [Discord][DISCORD].
 
 ## Working Group Members
 
-The working group sessions are public and everybody is welcome. If you are interested in discussions about identity and authentication on the IC, please join us.
+The working group sessions are public and everybody is welcome. If you are interested in discussions about identity and
+authentication on the IC, please join us.
 
 ### Permanent Members
-* DFINITY lead: [Frederik Rothenberger](https://github.com/frederikrothenberger)
-* Community Leads:
-  * [Dan Ostrovsky](https://github.com/dostro) (Identity Labs)
-  * [Bruce Huang](https://github.com/brutoshi) (AstroX)
+
+* DFINITY lead: [Thomas Gladdines](https://github.com/sea-snake)
+* Community Lead: [Dan Ostrovsky](https://github.com/dostro) (Identity Labs)
 * Coordinator: [Mary Dwyer](https://github.com/marydwyer)
 
+## Supported Signers
+
+The following list of signers have implemented or are implementing the standards in this working group:
+
+- [NFID](https://nfid.one)
+- [OISY](https://oisy.com)
+- [Plug](https://www.plugwallet.ooo)
+- [PrimeVault](https://www.primevault.com)
+
+Wallets and identity providers not listed here, might still be supported through adapters available in libraries and
+frameworks that implement the standards.
+
+Have you implemented the standards and your wallet isn't listed here? Contact us on the [forum][FORUM]
+or [Discord][DISCORD].
+
+## Libraries and Frameworks
+
+For a library that implements the above signer standards
+see [signer-js](https://www.npmjs.com/package/@slide-computer/signer).
+
+If you are looking to get started quickly, consider a framework like [IdentityKit](https://www.identitykit.xyz) that
+already implements the user interface, error handling, sessions and other details around wallets interaction.
+
+[//]: # (Status badges)
+
+[IDEA]: https://img.shields.io/badge/STATUS-IDEA-29abe2.svg
+
+[ISSUE]: https://img.shields.io/badge/STATUS-ISSUE-e7a237.svg
+
+[DRAFT]: https://img.shields.io/badge/STATUS-DRAFT-f25a24.svg
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg
+
+[STANDARD]: https://img.shields.io/badge/STATUS-STANDARD-572785.svg
+
+[ON HOLD]: https://img.shields.io/badge/STATUS-ON_HOLD-222222.svg
+
+[UNKNOWN]: https://img.shields.io/badge/STATUS-UNKNOWN-222222.svg
+
+[ABANDONED]: https://img.shields.io/badge/STATUS-ABANDONED-222222.svg
+
+[SUPERSEDED]: https://img.shields.io/badge/STATUS-SUPERSEDED-222222.svg
+
+[//]: # (Common links)
+
+[FORUM]: https://forum.dfinity.org/t/11902
+
+[DISCORD]: https://discord.internetcomputer.org
+
+[CALENDAR]: https://calendar.google.com/calendar/u/0/embed?src=c_cgoeq917rpeap7vse3is1hl310@group.calendar.google.com
+
+[RECORDINGS]: https://drive.google.com/drive/folders/14unuYLiYtUeOw47eRwYnB4FCa9YPr6zv
 
 
 

--- a/topics/ICRC-21/icrc_21_consent_msg.md
+++ b/topics/ICRC-21/icrc_21_consent_msg.md
@@ -1,6 +1,8 @@
 # ICRC-21: Canister Call Consent Messages
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
+![APPROVED]
+
+**Authors:** [Frederik Rothenberger](https://github.com/frederikrothenberger)
 
 ## Summary
 This specification describes a protocol for obtaining human-readable consent messages for canister calls. These messages are intended to be shown to users to help them make informed decisions about whether to approve a canister call / sign a transaction.
@@ -231,3 +233,5 @@ The message will then be shown to the user in the following context:
 │  └───────────┘   └───────────┘  │
 └─────────────────────────────────┘
 ```
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg

--- a/topics/icrc_25_signer_interaction_standard.md
+++ b/topics/icrc_25_signer_interaction_standard.md
@@ -1,9 +1,11 @@
-# ICRC-25: Signer Interaction Standard
+# ICRC-25: Signer Interaction
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
+![APPROVED]
+
+**Authors:** [Frederik Rothenberger](https://github.com/frederikrothenberger), [Thomas Gladdines](https://github.com/sea-snake), [Dan Ostrovsky](https://github.com/dostro)
 
 <!-- TOC -->
-* [ICRC-25: Signer Interaction Standard](#icrc-25-signer-interaction-standard)
+* [ICRC-25: Signer Interaction](#icrc-25-signer-interaction)
   * [Summary](#summary)
   * [Terminology](#terminology)
   * [Types](#types)
@@ -389,3 +391,5 @@ The error is an object comprising the `code`, `message` and optional `data` fiel
     }
 }
 ```
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg

--- a/topics/icrc_27_accounts.md
+++ b/topics/icrc_27_accounts.md
@@ -1,7 +1,8 @@
 # ICRC-27: Accounts
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
-[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
+![APPROVED] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Thomas Gladdines](https://github.com/sea-snake)
 
 <!-- TOC -->
 * [ICRC-27: Accounts](#icrc-27-accounts)
@@ -136,3 +137,7 @@ signer does not have the capability to show and transfer tokens of this token st
 
 A relying party MAY only transfer unsupported tokens to a signer account if the relying party is at least able to offer
 the capability to show and transfer the tokens held by the signer account itself.
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/icrc_28_trusted_origins.md
+++ b/topics/icrc_28_trusted_origins.md
@@ -1,7 +1,8 @@
 # ICRC-28: Trusted Origins
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
-[![Standard Issue](https://img.shields.io/badge/ISSUE-ICRC--28-blue?logo=github)](https://github.com/dfinity/wg-identity-authentication/issues/115)
+![APPROVED]
+
+**Authors:** [Dan Ostrovsky](https://github.com/dostro)
 
 <!-- TOC -->
 * [ICRC-28: Trusted Origins](#icrc-28-trusted-origins)
@@ -113,3 +114,5 @@ sequenceDiagram
         S ->> RP: Signed Relying Party Delegation
     end
 ```
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg

--- a/topics/icrc_29_window_post_message_transport.md
+++ b/topics/icrc_29_window_post_message_transport.md
@@ -1,6 +1,8 @@
-# ICRC-29: Window Post Message Transport for ICRC-25
+# ICRC-29: Browser Post Message Transport
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
+![APPROVED] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Frederik Rothenberger](https://github.com/frederikrothenberger), [Thomas Gladdines](https://github.com/sea-snake)
 
 ## Summary
 
@@ -87,3 +89,7 @@ If the signer window is closed unexpectedly, the relying party will stop receivi
 ### Invalid Messages
 
 If either party receives malformed, unexpected, or otherwise invalid messages, it should ignore them.
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/icrc_32_sign_challenge.md
+++ b/topics/icrc_32_sign_challenge.md
@@ -1,7 +1,8 @@
 # ICRC-32: Sign Challenge
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
-[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
+![ON HOLD] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Philipp Litzenberger](https://github.com/plitzenberger), [Frederik Rothenberger](https://github.com/frederikrothenberger)
 
 <!-- TOC -->
 * [ICRC-32: Sign Challenge](#icrc-32-sign-challenge)
@@ -18,6 +19,7 @@
     * [Without Delegation](#without-delegation)
     * [With Delegation](#with-delegation)
 <!-- TOC -->
+
 ## Summary
 
 The purpose of the `icrc32_sign_challenge` method is for the relying party to receive a cryptographic proof of ownership for the users identities.
@@ -204,3 +206,7 @@ Response
     }
 }
 ```
+
+[ON HOLD]: https://img.shields.io/badge/STATUS-ON_HOLD-222222.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/icrc_34_delegation.md
+++ b/topics/icrc_34_delegation.md
@@ -1,8 +1,8 @@
 # ICRC-34: Delegation
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
-[![Extension Badge](https://img.shields.io/badge/EXTENDS-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
-[![Standard Issue](https://img.shields.io/badge/ISSUE-ICRC--34-blue?logo=github)](https://github.com/dfinity/wg-identity-authentication/issues/115)
+![APPROVED] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Dan Ostrovsky](https://github.com/dostro), [Thomas Gladdines](https://github.com/sea-snake)
 
 <!-- TOC -->
 * [ICRC-34: Delegation](#icrc-34-delegation)
@@ -202,3 +202,7 @@ the [IC interface specification, authentication section](https://internetcompute
 
 This standard does not define additional errors. See [ICRC-25](./icrc_25_signer_interaction_standard.md#errors-3) for a
 list of errors that can be returned by all methods.
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/icrc_49_call_canister.md
+++ b/topics/icrc_49_call_canister.md
@@ -1,7 +1,8 @@
 # ICRC-49: Call Canister
 
-[![Status Badge](https://img.shields.io/badge/STATUS-WG_APPROVED-purple.svg)](https://github.com/orgs/dfinity/projects/31)
-[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
+![APPROVED] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Frederik Rothenberger](https://github.com/frederikrothenberger)
 
 <!-- TOC -->
 * [ICRC-49: Call Canister](#icrc-49-call-canister)
@@ -188,3 +189,7 @@ This standard defines the following additional errors:
 | Code | Message            | Meaning                                                                                                                      | Data |
 |------|--------------------|------------------------------------------------------------------------------------------------------------------------------|------|
 | 2001 | No consent message | The signer has rejected the request because the target canister does not support ICRC-21 consent messages for the given call | N/A  |
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/icrc_94_multi_injected_provider_discovery.md
+++ b/topics/icrc_94_multi_injected_provider_discovery.md
@@ -1,6 +1,8 @@
-# ICRC-94: Multi Injected Provider Discovery for ICRC-25
+# ICRC-94: Browser Extension Discovery and Transport
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
+![DRAFT] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Thomas Gladdines](https://github.com/sea-snake), [Dan Ostrovsky](https://github.com/dostro)
 
 ## Summary
 
@@ -90,3 +92,6 @@ The relying party can then subsequently inform the user to make a decision e.g. 
 
 If either party receives malformed, unexpected, or otherwise invalid messages, it should ignore them.
 
+[DRAFT]: https://img.shields.io/badge/STATUS-DRAFT-f25a24.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/icrc_95_derivationorigin.md
+++ b/topics/icrc_95_derivationorigin.md
@@ -1,10 +1,11 @@
-# ICRC-95: derivationOrigin
+# ICRC-95: Derivation Origin
 
-[![Status Badge](https://img.shields.io/badge/STATUS-DRAFT-ffcc00.svg)](https://github.com/orgs/dfinity/projects/31)
-[![Extension Badge](https://img.shields.io/badge/Extends-ICRC--25-ffcc222.svg)](./icrc_25_signer_interaction_standard.md)
+![APPROVED] [![EXTENDS 25]](./icrc_25_signer_interaction_standard.md)
+
+**Authors:** [Dan Ostrovsky](https://github.com/dostro)
 
 <!-- TOC -->
-* [ICRC-95: derivationOrigin](#icrc-95-derivationorigin)
+* [ICRC-95: Derivation Origin](#icrc-95-derivation-origin)
   * [Summary](#summary)
   * [Motivation](#motivation)
   * [Specification](#specification)
@@ -12,7 +13,7 @@
     * [derivationOrigin Parameter](#derivationorigin-parameter)
   * [Reference Implementation](#reference-implementation)
     * [Signer](#signer)
-    * [DApp Implementation](#dapp-implementation)
+  * [DApp Implementation](#dapp-implementation)
 <!-- TOC -->
 
 ## Summary
@@ -67,3 +68,7 @@ Here is the DApp's request for a delegation using ICRC-95: derivationOrigin:
   }
 }
 ```
+
+[APPROVED]: https://img.shields.io/badge/STATUS-APPROVED-ed1e7a.svg
+
+[EXTENDS 25]: https://img.shields.io/badge/EXTENDS-ICRC--25-ed1e7a.svg

--- a/topics/signer_standards_overview.md
+++ b/topics/signer_standards_overview.md
@@ -3,69 +3,119 @@
 This document gives an overview over the ICRC standards related to signer interactions and transaction approval flows.
 It explains the motivation behind the standards and how they relate to each other.
 
-The following ICRC standards are relevant in this context:
-* The [Internet Computer Interface Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec/), specifically the [HTTPs interface](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-interface)
-* [ICRC-21](ICRC-21/icrc_21_consent_msg.md): Canister Call Consent Messages
-* [ICRC-25](icrc_25_signer_interaction_standard.md): Signer Interaction Standard
-* [ICRC-27](icrc_27_get_accounts.md): Get accounts (ICRC-25 Extension)
-* [ICRC-29](icrc_29_window_post_message_transport.md): PostMessage Transport Standard for ICRC-25
-* [ICRC-32](icrc_32_sign_challenge.md): Sign Challenge (ICRC-25 Extension)
-* [ICRC-39](icrc_39_batch_calling.md): Batch Calling (ICRC-25 Extension)
-* [ICRC-49](icrc_49_call_canister.md): Call Canister (ICRC-25 Extension)
+The following diagram presents the interactions between the different components and shows which standards cover the
+respective parts of the interactions:
 
-The following diagram presents the interactions between the different components (see [terminology](#terminology)) and shows which standards cover the respective parts of the interactions:
+```mermaid
+graph LR
+    RP[Relying<br>Party]
+    User((User))
+    Signer[Signer]
+    Canister[(Target<br>Canister)]
+    Messages["JSON-RPC Messages<br>(ICRC-25 including extensions)"]
+    Calls[Canister Calls:<br>- ICRC-21<br>- ICRC-49]
 
-![Visualization showing which part of the interactions between relying party, signer and target canister are covered by which standard.](../diagrams/signer_standards_overview.svg "Signer Standards Overview")
+    subgraph Transport[Transport Channel e.g. ICRC-29]
+        Messages
+    end
 
-## Terminology
+    subgraph HTTP[IC HTTP Interface]
+        Calls
+    end
 
-### Signer 
+    subgraph IC[Internet Computer]
+        Canister
+    end
+
+    RP --- Messages ---> Signer
+    Signer --- Calls --> Canister
+    User <-- " Interactions:<br>- Account selection<br>- Permission requests<br>- User approvals " --> Signer
+    User -- Interactions --> RP
+    
+    style RP fill:#93e898,stroke:transparent,color:#000001
+    style Transport fill:#025eb155,stroke:transparent
+    style Messages fill:#a73838,stroke:transparent,color:#fffffe
+    style Signer fill:#fff781,stroke:transparent,color:#000001
+    style HTTP fill:#cccccc22,stroke:transparent
+    style IC fill:#cccccc22,stroke:transparent
+    style Calls fill:#67511b,text-align:left,stroke:transparent,color:#fffffe
+    style Canister fill:#eaabff,text-align:left,stroke:#8f38a7,color:#000001
+    linkStyle 4 text-align:left
+```
+
+### 🟨 Signer
+
 A component that holds a private key and can sign messages. In addition, the signer needs to be able to interact
 with the IC to send messages and receive responses.
 It can be a hardware wallet, a mobile app, a browser extension, or any other component that can sign messages.
 
 A signer is _not_ required to do any form of asset management, such as showing balances or manage staked funds.
 
-### Relying Party
-A service that interacts with a signer. It can do so by requesting
-* information (see [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) & ICRC-27), such as the list of identities managed by the signer. Additional information can be shared if defined in ICRC-25 extensions, such as e.g. ICRC-1 subaccounts defined in ICRC-27.
-* signatures for specific messages / transactions that are then submitted to the IC (see [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md))
-* a delegation to act on the signers' behalf.
+### 🟩 Relying Party
 
-This service can be a webapp (either hosted on-chain (dapp) or using the classical web 2.0 model), a mobile app, or any other service.
+A service that interacts with a signer.
 
-### Target Canister
+This service can be a webapp (either hosted on-chain (dapp) or using the classical web 2.0 model), a mobile app, or any
+other service.
+
+### 🟪 Target Canister
+
 The target canister is a canister hosted on the IC. The target canister is chosen by the relying party as the recipient
 of a message that is signed by the signer.
 
-For example, the target might be a canister that holds assets, such as the ICP ledger canister, and a relying party might
-want to request a transfer of ICP to some specific account.
+For example, the target might be a canister that holds assets, such as the ICP ledger canister, and a relying party
+might want to request a transfer of ICP to some specific account.
+
+### 🟥 JSON-RPC Messages
+
+[Standards](../README.md#json-rpc-messages) that describe interactions between relying parties and signers with JSON-RPC messages.
+
+### 🟦 Transport Channel
+
+[Standards](../README.md#transport-channel) that describe how the communication channel between a relying party and signer is established.
+
+### 🟫 Canister Calls
+
+[Standards](../README.md#canister-calls) that describe canister call interfaces used by signers.
 
 ## Motivation
 
-Currently, it is very cumbersome to manage assets in the IC ecosystem. The reason is, that there are no established standards
+Currently, it is very cumbersome to manage assets in the IC ecosystem. The reason is, that there are no established
+standards
 on how to interact with wallets / signers. On top of that, the privacy-preserving model of authorizing dapps by issuing
-delegations (as used by Internet Identity and other identity providers) makes it challenging to manage assets that are shared
+delegations (as used by Internet Identity and other identity providers) makes it challenging to manage assets that are
+shared
 across many different services.
 
 The standards referenced in this document aim to provide a lightweight framework for signers to interact with services
-under a common, shared identity. The standards are split in different parts to allow projects to pick and chose the parts
+under a common, shared identity. The standards are split in different parts to allow projects to pick and chose the
+parts
 that they need. Care was taken to make the standards extensible to open up the space to the community to define the
 extensions they need and prove useful in practice.
 
-If these standards are adopted, the vision is to foster a vibrant and diverse ecosystem of signers, dapps, and canisters that
+If these standards are adopted, the vision is to foster a vibrant and diverse ecosystem of signers, dapps, and canisters
+that
 can interact with each other, _without_ having to specifically integrate with any particular component (or even know
-about each others existence prior to the interaction). To help with this, services maintained by DFINITY will be upgraded
+about each others existence prior to the interaction). To help with this, services maintained by DFINITY will be
+upgraded
 to support these standards, when they are adopted.
 
 ## Delegation Identities vs Signer Identities
 
-The signer standards are meant as an extension of the current delegation based model (and not as a replacement). There is a lot of value in having authenticated sessions and being able to make many transactions non-interactively, leveraging the high throughput of the IC. For security critical / high-value transactions and for interactions that require a stable identity across applications the signer standards provide a better alternative.
+The signer standards are meant as an extension of the current delegation based model (and not as a replacement). There
+is a lot of value in having authenticated sessions and being able to make many transactions non-interactively,
+leveraging the high throughput of the IC. For security critical / high-value transactions and for interactions that
+require a stable identity across applications the signer standards provide a better alternative.
 
-From a user perspective, the delegation based session identity should be a technical detail. The user should not have to know the principal of that identity (or even be aware of its existence). In contrast, the signer identities are explicitly and directly managed by the user.
+From a user perspective, the delegation based session identity should be a technical detail. The user should not have to
+know the principal of that identity (or even be aware of its existence). In contrast, the signer identities are
+explicitly and directly managed by the user.
 
-Application developers should take advantage of that distinction by handing over the responsibility over valuable assets to the signer identities (and hence the user). This is especially important for assets that are shared across many different services.
-By doing so, the applications can focus on the business logic and user experience, while the signer takes care of the security of the assets.
+Application developers should take advantage of that distinction by handing over the responsibility over valuable assets
+to the signer identities (and hence the user). This is especially important for assets that are shared across many
+different services.
+By doing so, the applications can focus on the business logic and user experience, while the signer takes care of the
+security of the assets.
 
 ![Visualization showing how a dapp should interact with the IC given a delegation identity and a signer identity](../diagrams/delegation-identity-vs-signer-identity.png "Delegation Identity vs Signer Identity")
 
@@ -76,8 +126,8 @@ By doing so, the applications can focus on the business logic and user experienc
 | Examples            | <ul><li>retrieve application-specific user data</li><li>poll for notifications</li><li>update application-specific data</li></ul>                    | <ul><li>transfer of currencies (ICP, ckBTC, Cycles, ...)</li><li>creating and managing neurons (increase stake, disburse maturity, change dissolve delay...)</li><li>Creating and managing canisters (changing controllers, installing code...)</li></ul> |
 | Security Properties | <ul><li>under dapp control</li><li>not visible to the user</li><li>time limited</li><li>unrevokable</li></ul>                                        | <ul><li>under signer control</li><li>explicit user interaction</li><li>one-off approvals</li><li>defense in depth mechanism against dapp session hijacking</li></ul>                                                                                      |
 
-
 ## Trust Assumptions
+
 This section explains the trust assumptions that are made by the standards. In the context of these standards, one party
 trusting another party means that the trusting party relies on the trusted party to behave honestly and according to the
 standards. In particular, if trust is misplaced then the trusting party cannot detect or prevent the malicious behaviour
@@ -87,12 +137,17 @@ For example, if a user were to try to manage their assets using a malicious sign
 for the user to prevent the signer from stealing their assets.
 
 The trust assumptions are as follows:
+
 * The signer is trusted by the user.
-* The target canister is trusted by the user. Interactions with malicious canisters are not covered by the standards. In particular, interacting with a malicious canister can produce arbitrary outcomes regardless of how the calls were signed.
+* The target canister is trusted by the user. Interactions with malicious canisters are not covered by the standards. In
+  particular, interacting with a malicious canister can produce arbitrary outcomes regardless of how the calls were
+  signed.
 * The relying party is _not_ trusted by the user nor the signer and might be malicious.
-* The signer is _not_ trusted by the relying party. The relying party must be able to detect malicious behaviour from a signer
+* The signer is _not_ trusted by the relying party. The relying party must be able to detect malicious behaviour from a
+  signer
   with respect to the relying party.
-  This property is important for an open ecosystem where relying parties openly interact with any standard compliant signer.
+  This property is important for an open ecosystem where relying parties openly interact with any standard compliant
+  signer.
 
 ## Use Cases
 
@@ -100,37 +155,52 @@ This section lists the use cases that are covered by the standards.
 
 ### Use Case 1: Sharing Information with a Relying Party
 
-In this use case the relying party does not require signing canister calls, but only information about the identities (and potentially subaccounts) managed by the signer.
+In this use case the relying party does not require signing canister calls, but only information about the identities (
+and potentially subaccounts) managed by the signer.
 
-To exchange this information, the relying party establishes a connection with the signer and requests the information using the appropriate messages, such as `icrc31_get_principals` message as specified by [ICRC-31](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_31_get_principals.md). The information that is shared this way is subject to user approval on the signer side.
+To exchange this information, the relying party establishes a connection with the signer and requests the information
+using the appropriate messages, such as `icrc31_get_principals` message as specified
+by [ICRC-31](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_31_get_principals.md). The
+information that is shared this way is subject to user approval on the signer side.
 
 Currently, the following information can be shared:
-* The list of identities managed by the signer, as specified by [ICRC-31](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_31_get_principals.md).
+
+* The list of identities managed by the signer, as specified
+  by [ICRC-31](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_31_get_principals.md).
 * The list of ICRC-1 subaccounts associated with the identities managed by the signer, as specified by ICRC-27
 
 More extensions can be added in the future.
 
 ### Use Case 2: Relying Party Initiated Transaction Approval Flow
 
-In this use case the relying party initiates canister calls (transactions) on behalf of an identity controlled by a signer.
-The user can approve or reject the transaction on the signer UI. After user approval, the signer signs the call and submits it to the IC. Upon receiving the result of the canister call, the signer must forward the result to the relying party.
+In this use case the relying party initiates canister calls (transactions) on behalf of an identity controlled by a
+signer.
+The user can approve or reject the transaction on the signer UI. After user approval, the signer signs the call and
+submits it to the IC. Upon receiving the result of the canister call, the signer must forward the result to the relying
+party.
 
-This flow (described in [ICRC-49](icrc_49_call_canister.md)) is one of the main use cases for [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md). It offers an alternative interaction model to the currently used session delegations.
-In particular, it allows multiple relying parties to securely interact with the IC using the same signer controlled identity
+This flow (described in [ICRC-49](icrc_49_call_canister.md)) is one of the main use cases
+for [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md).
+It offers an alternative interaction model to the currently used session delegations.
+In particular, it allows multiple relying parties to securely interact with the IC using the same signer controlled
+identity
 without being restricted to a disjoint set of target canisters.
 
 In the future, batch transactions could be a possible extensions to this flow.
 
 ## Signer Architecture
 
-The signer architecture is not part of the standards. Any component that fulfills the following requirements can act as a signer:
+The signer architecture is not part of the standards. Any component that fulfills the following requirements can act as
+a signer:
+
 - Ability to sign messages with an IC supported signature scheme
 - Ability to verify messages signed with an IC supported signature scheme
 - Ability to interact with the IC to send messages and receive responses
 - Implementation of an appropriate transport channel to communicate with a relying party
 
 User interaction is not mandated as developers should be able to build signers that don't interact directly with users.
-However, the most common implementation is expected to be a signer that is interactive and displays transaction information
+However, the most common implementation is expected to be a signer that is interactive and displays transaction
+information
 to the user and receives user input synchronously.
 
 This section gives an overview over the different types that were
@@ -143,6 +213,7 @@ considered when designing the standards.
 This is a signer whose private keys to sign messages are stored off-chain.
 
 Examples of such signers would be:
+
 * a mobile app
 * a browser extension
 * a webapp that signs message using a WebAuthn credential
@@ -157,12 +228,14 @@ Note that while the canister is holding all the assets, it is not using the cani
 self-authenticating principal derived from the canister signature public key is the owner of the assets.
 
 This indirection is required because of the different trust models for external parties as opposed to canisters:
+
 * A canister can trust the responses it receives from other canister because the execution is replicated
-  * cross-subnet calls are validated by the receiving subnet
+    * cross-subnet calls are validated by the receiving subnet
 * An external party always communicates with a single, untrusted boundary node.
   Therefore, the responses are certified by the subnet to prove authenticity.
 
-[ICRC-49](icrc_49_call_canister.md) requires the certified response to be relayed to the relying party as the signer is not trusted by the relying
+[ICRC-49](icrc_49_call_canister.md) requires the certified response to be relayed to the relying party as the signer is
+not trusted by the relying
 party.
 
 The above approach also sidesteps another issues that arise from holding assets using a canister id principal:
@@ -170,17 +243,9 @@ calling untrusted canisters is generally unsafe as it can prevent upgrades of th
 
 #### Air-Gapped Signers
 
-An air-gapped signer is a signer that is not connected to the internet. As [ICRC-49](icrc_49_call_canister.md) requires signers to have a connection
-to the IC, air-gapped signers are only supported by this extension standard if they provide a chain-connected component as well.
+An air-gapped signer is a signer that is not connected to the internet. As [ICRC-49](icrc_49_call_canister.md) requires
+signers to have a connection
+to the IC, air-gapped signers are only supported by this extension standard if they provide a chain-connected component
+as well.
 
 The chain-connected component must be trusted by the user.
-
-## Supported Transports
-
-The standards are written in a transport agnostic way (apart from ICRC-29) to allow for different transports to be used.
-In particular, [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) was designed to make it possible to use it across the following transports:
-* Browser Window.postMessage: because it is an easy to use transport that is available in all browsers
-* Wallet Connect: because it is a widely used standard in the crypto space
-* App switch on mobile devices: because it is a common pattern on mobile devices
-
-However, this list is not exhaustive and other transports can be used as well as long as they meet the requirements specified in [ICRC-25](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md).


### PR DESCRIPTION
Update readme and align it with overview.

Changes:
- Update status labels to align with process in practice
- Update process description to clarify process further
- Remove topic, lead, and link columns from standards table
- Split large standards table into multiple smaller topic specific tables.
- Move standards that haven't had progress for a while to other table
- Add author(s) to every standard
- Mention in meetings section that schedule announcements and summaries can be found on the forum
- Update contributing guidelines to refer to forum or Discord
- Update working group members
- Add supported signers section
- Add libraries and frameworks section
- Replace signer overview diagram with embedded mermaid graph
- Reference topic specific standard tables from signer overview