### PR TITLE
Replace LineDisplay with FieldsDisplay in ICRC-21

### DIFF
--- a/topics/ICRC-21/ICRC-21.did
+++ b/topics/ICRC-21/ICRC-21.did
@@ -23,15 +23,10 @@ type icrc21_consent_message_spec = record {
         // A generic display able to handle large documents and do line wrapping and pagination / scrolling.
         // Text must be Markdown formatted, no external resources (e.g. images) are allowed.
         GenericDisplay;
-        // Simple display able to handle lines of text with a maximum number of characters per line.
-        // Multiple pages can be used if the text does no fit on a single page.
+        // A simple display able to handle multiple pages with a title and content.
+        // It's able to do line wrapping and splits pages into multiple if they're too long.
         // Text must be plain text without any embedded formatting elements.
-        LineDisplay: record {
-            // Maximum number of characters that can be displayed per line.
-            characters_per_line: nat16;
-            // Maximum number of lines that can be displayed at once on a single page.
-            lines_per_page: nat16;
-        };
+        PageDisplay;
     };
 };
 
@@ -48,16 +43,15 @@ type icrc21_consent_message = variant {
     // Message for a generic display able to handle large documents and do proper line wrapping and pagination / scrolling.
     // Uses Markdown formatting, no external resources (e.g. images) are allowed.
     GenericDisplayMessage: text;
-    // Message for a simple display able to handle pages with multiple lines of text with a fixed maximum number of
-    // characters per line.
-    // Multiple pages can be used if the text does no fit on a single page.
+    // Message for a simple display able to handle multiple pages with a title and content.
+    // It's able to do line wrapping and splits pages into multiple if they're too long.
     // Uses plain text, without any embedded formatting elements.
-    LineDisplayMessage: record {
+    PageDisplayMessage: record {
         pages: vec record {
-            // Lines of text to be displayed on a single page.
-            // Must not have more entries (lines) than specified in the icrc21_consent_message_spec.
-            // Lines must not exceed the number of characters per line specified in the icrc21_consent_message_spec.
-            lines: vec text;
+            // Optional title shown above content e.g. Expiration date
+            title: opt text;
+            // Content shown below title e.g. Friday, February 21, 2025, at 09:56:45 UTC
+            content: text;
         };
     };
 };

--- a/topics/ICRC-21/ICRC-21.did
+++ b/topics/ICRC-21/ICRC-21.did
@@ -23,10 +23,10 @@ type icrc21_consent_message_spec = record {
         // A generic display able to handle large documents and do line wrapping and pagination / scrolling.
         // Text must be Markdown formatted, no external resources (e.g. images) are allowed.
         GenericDisplay;
-        // A simple display able to handle multiple pages with a title and content.
-        // It's able to do line wrapping and splits pages into multiple if they're too long.
+        // A simple display able to handle multiple fields with a title and content.
+        // It's able to do line wrapping and splits fields into multiple pages if they're too long.
         // Text must be plain text without any embedded formatting elements.
-        PageDisplay;
+        FieldsDisplay;
     };
 };
 
@@ -43,16 +43,16 @@ type icrc21_consent_message = variant {
     // Message for a generic display able to handle large documents and do proper line wrapping and pagination / scrolling.
     // Uses Markdown formatting, no external resources (e.g. images) are allowed.
     GenericDisplayMessage: text;
-    // Message for a simple display able to handle multiple pages with a title and content.
-    // It's able to do line wrapping and splits pages into multiple if they're too long.
+    // Message for a simple display able to handle multiple fields title and content.
+    // It's able to do line wrapping and splits fields into multiple pages if they're too long.
     // Uses plain text, without any embedded formatting elements.
-    PageDisplayMessage: record {
-        pages: vec record {
-            // Optional title shown above content e.g. Expiration date
-            title: opt text;
-            // Content shown below title e.g. Friday, February 21, 2025, at 09:56:45 UTC
-            content: text;
-        };
+    FieldsDisplayMessage: record {
+        // Context and type of transaction, accurate and concise e.g. Review transaction to send ICP
+        title: text;
+        // Transaction fields for review e.g. Amount 234.73 ICP
+        fields: vec record { text; text };
+        // The action taken by the user after review e.g. Sign transaction to send ICP
+        action: text;
     };
 };
 

--- a/topics/ICRC-21/icrc_21_consent_msg.md
+++ b/topics/ICRC-21/icrc_21_consent_msg.md
@@ -2,7 +2,7 @@
 
 ![APPROVED]
 
-**Authors:** [Frederik Rothenberger](https://github.com/frederikrothenberger)
+**Authors:** [Frederik Rothenberger](https://github.com/frederikrothenberger), [Thomas Gladdines](https://github.com/sea-snake)
 
 ## Summary
 This specification describes a protocol for obtaining human-readable consent messages for canister calls. These messages are intended to be shown to users to help them make informed decisions about whether to approve a canister call / sign a transaction.


### PR DESCRIPTION
Replace LineDisplay with FieldsDisplay in ICRC-21.

LineDisplay doesn't align with ongoing Ledger HW Wallet implementation, so to better align with these ongoing efforts, a new display type FieldsDisplay has been added.

Keeping both LineDisplay and FieldsDisplay was discussed and considered, but removing LineDisplay seems the better approach since:
- ICRC-21 has not passed ICRC voting yet so it can still be modified, though this is still to be avoided in most cases.
- No use cases and/or implementations have been identifier for LineDisplay, if your project relies on LineDisplay, please reach out in this PR.
- Keeping it would unnecessarily require support from canisters for a display spec that's not being used.