### PR TITLE
Refactor to move from errors within individual responses to a single …

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Before jumping into the standards, it's recommended to read the overview [here](
 
 Standards that describe interactions between relying parties and signers through JSON-RPC messages.
 
-| Standard                                                                                      | Status      |
-|-----------------------------------------------------------------------------------------------|-------------|
-| [ICRC-25: Signer Interaction](./topics/icrc_25_signer_interaction_standard.md)                | ![APPROVED] |
-| [ICRC-27: Accounts](./topics/icrc_27_accounts.md)                                             | ![APPROVED] |
-| [ICRC-34: Delegation](./topics/icrc_34_delegation.md)                                         | ![APPROVED] |
-| [ICRC-49: Call Canister](./topics/icrc_49_call_canister.md)                                   | ![APPROVED] |
-| [ICRC-95: Derivation Origin](./topics/icrc_95_derivationorigin.md)                            | ![APPROVED] |
-| [ICRC-#: Batch Call Canister](https://github.com/dfinity/wg-identity-authentication/pull/220) | ![ISSUE]    |
+| Standard                                                                       | Status      |
+|--------------------------------------------------------------------------------|-------------|
+| [ICRC-25: Signer Interaction](./topics/icrc_25_signer_interaction_standard.md) | ![APPROVED] |
+| [ICRC-27: Accounts](./topics/icrc_27_accounts.md)                              | ![APPROVED] |
+| [ICRC-34: Delegation](./topics/icrc_34_delegation.md)                          | ![APPROVED] |
+| [ICRC-49: Call Canister](./topics/icrc_49_call_canister.md)                    | ![APPROVED] |
+| [ICRC-95: Derivation Origin](./topics/icrc_95_derivationorigin.md)             | ![APPROVED] |
+| [ICRC-112: Batch Call Canister](./topics/icrc_112_batch_call_canister.md)      | ![DRAFT]    |
 
 ### Transport Channel
 
@@ -71,6 +71,7 @@ Standards that describe canister call interfaces used by signers.
 |----------------------------------------------------------------------------------------------------|-------------|
 | [ICRC-21: Canister Call Consent Messages](./topics/ICRC-21/icrc_21_consent_msg.md)                 | ![APPROVED] |
 | [ICRC-28: Trusted Origins](./topics/icrc_28_trusted_origins.md)                                    | ![APPROVED] |
+| [ICRC-114: Validate Batch Call](./topics/icrc_114_validate_batch_call.md)                          | ![DRAFT]    |
 | [ICRC-#: Dapp Metadata Registry](https://github.com/dfinity/wg-identity-authentication/issues/156) | ![ISSUE]    |
 
 ### Other

--- a/topics/icrc_112_batch_call_canister.md
+++ b/topics/icrc_112_batch_call_canister.md
@@ -371,7 +371,7 @@ Recommended approach to recover from partial responses as relying party:
 
 1. Check the last sub-array that contains processed responses:
     - Check if processed responses are valid by either validating the candid response directly or by calling the validation canister directly.
-    - In case of using the validation canister, consider an additional canister method that returns more than a boolean e.g. error message and instructions to show to user.
+    - In case of using the validation canister, consider implementing and using an additional canister method that returns more than a boolean e.g. error message and instructions to show to user.
     - Resolve underlying issues that caused the error that resulted in partial responses e.g. not enough funds.
     - Inform the user of the error(s) and ask them to take certain actions where needed.
 2. Re-submit the `icrc112_batch_call_canister` request with the successful canister call requests omitted.

--- a/topics/icrc_112_batch_call_canister.md
+++ b/topics/icrc_112_batch_call_canister.md
@@ -371,6 +371,7 @@ Recommended approach to recover from partial responses as relying party:
 
 1. Check the last sub-array that contains processed responses:
     - Check if processed responses are valid by either validating the candid response directly or by calling the validation canister directly.
+    - In case of using the validation canister, consider an additional canister method that returns more than a boolean e.g. error message and instructions to show to user.
     - Resolve underlying issues that caused the error that resulted in partial responses e.g. not enough funds.
     - Inform the user of the error(s) and ask them to take certain actions where needed.
 2. Re-submit the `icrc112_batch_call_canister` request with the successful canister call requests omitted.

--- a/topics/icrc_112_batch_call_canister.md
+++ b/topics/icrc_112_batch_call_canister.md
@@ -62,9 +62,9 @@ There is only one response from ICRC-112, not separate responses for individual 
 // Example execution order
 {
   "requests": [
-    ["request1", "request2", "request3"],   // Requests 1-3 execute in parallel
+    ["request1", "request2", "request3"], // Requests 1-3 execute in parallel
     ["request4", "request5"],             // Requests 4-5 execute in parallel, after requests 1-3 are validated
-    ["request6"]                        // Request 6 executes, after requests 4-5 are validated (request 6 itself is not validated)
+    ["request6"]                          // Request 6 executes, after requests 4-5 are validated (request 6 itself is not validated)
   ]
 }
 ```

--- a/topics/icrc_112_batch_call_canister.md
+++ b/topics/icrc_112_batch_call_canister.md
@@ -329,7 +329,7 @@ A `null` value is returned for requests that weren't processed.
 
 ## Errors
 
-In addition to the errors defined in [ICRC-25](./icrc_25_signer_interaction_standard.md#errors-3) this standard defines the following errors. Please note that if ICRC-112 stops executing becausse it encounters an error, it will mark all remaining requests that were never executed with 1001.
+In addition to the errors defined in [ICRC-25](./icrc_25_signer_interaction_standard.md#errors-3) this standard defines the following errors.
 
 | Code | Message             | Meaning                                                                                                                                                   | Data                                                                                |
 |------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|

--- a/topics/icrc_114_validate_batch_call.md
+++ b/topics/icrc_114_validate_batch_call.md
@@ -1,4 +1,4 @@
-# ICRC-114: Validate batch response
+# ICRC-114: Validate Batch Call
 
 ![DRAFT] 
 

--- a/topics/icrc_114_validate_batch_call.md
+++ b/topics/icrc_114_validate_batch_call.md
@@ -128,7 +128,7 @@ Signer executes ICRC-112 request via JSON RPC. We assume the signer supports ICR
           "canisterId": "xyzzz-fqaaa-aaaao-a2hlq-ca",
           "method": "swap",
           "arg": "RElETARte24AbAKzsNrDA2ithsqDBQFsA/vKAQKi3pTrBgHYo4yoDX0BAwEdV+ztKgq7E4l1ffuTuwEmw8AtYSjlrJ+WLO5ofQIAAMgB",
-          "nonce": [1, 2, 3, 2, 31, 31, 312] // array of bytes
+          "nonce": "RElETARte24AbAKzsNrDA2ithsqDBQFsA/vKAQKi3pTrBgHYo4yoDX0BAwEdV+ztKgq7E4l1ffuTuwEmw8AtYSjlrJ+WLO5ofQIAAMgB"
         }
       ],
       [


### PR DESCRIPTION
- Refactor to move from errors within individual responses to a single error that has partial responses as additional data.
- Rename method from `icrc112_batch_canister_call` to `icrc112_batch_call_canister` so it aligns with `icrc49_call_canister`.